### PR TITLE
xExchDatabaseAvailabilityGroupMember: Remove Windows Failover-Clustering check while adding DAG member

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 # Change log for xExchange
 
 ## Unreleased
+- Remove check for Windows Failover-Clustering role before adding a new DAG member
 
 ## 1.30.0.0
 

--- a/DSCResources/MSFT_xExchDatabaseAvailabilityGroupMember/MSFT_xExchDatabaseAvailabilityGroupMember.psm1
+++ b/DSCResources/MSFT_xExchDatabaseAvailabilityGroupMember/MSFT_xExchDatabaseAvailabilityGroupMember.psm1
@@ -104,14 +104,8 @@ function Set-TargetResource
 
     $failoverClusteringRole = Get-WindowsFeature -Name Failover-Clustering -ErrorAction SilentlyContinue
 
-    # Make sure the Failover-Clustering role is installed before trying to add the member to the DAG
-    if ($null -eq $failoverClusteringRole -or !$failoverClusteringRole.Installed)
-    {
-        Write-Error -Message 'The Failover-Clustering role must be fully installed before the server can be added to the cluster.'
-        return
-    }
     # Force a reboot if the cluster is in an InstallPending state
-    elseif ($failoverClusteringRole.InstallState -like 'InstallPending')
+    if ($failoverClusteringRole.InstallState -like 'InstallPending')
     {
         Write-Warning -Message 'A reboot is required to finish installing the Failover-Clustering role. This must occur before the server can be added to the DAG.'
         Set-DSCMachineStatus -NewDSCMachineStatus 1


### PR DESCRIPTION
#### Pull Request (PR) description
While adding a server as a new member to a DAG, Exchange automatically installs the necessary Windows Failover-Clustering role. So no need to install it before. If it is installed before, adding the server to the DAG sometimes fails because the cluster service is already running. Therefore I removed the check if the role is installed before running Add-DatabaseAvailabilityGroupServer.

#### This Pull Request (PR) fixes the following issues
None

#### Task list

- [ x] Added an entry under the Unreleased section of the change log in the CHANGELOG.md.
      Entry should say what was changed, and how that affects users (if applicable).
- [ ] Resource documentation added/updated in README.md.
- [ ] Resource parameter descriptions added/updated in README.md, schema.mof
      and comment-based help.
- [ ] Comment-based help added/updated.
- [ ] Localization strings added/updated in all localization files as appropriate.
- [ ] Examples appropriately added/updated.
- [ ] Unit tests added/updated. See [DSC Resource Testing Guidelines](https://github.com/PowerShell/DscResources/blob/master/TestsGuidelines.md).
- [ ] Integration tests added/updated (where possible). See [DSC Resource Testing Guidelines](https://github.com/PowerShell/DscResources/blob/master/TestsGuidelines.md).
- [ ] New/changed code adheres to [DSC Resource Style Guidelines](https://github.com/PowerShell/DscResources/blob/master/StyleGuidelines.md) and [Best Practices](https://github.com/PowerShell/DscResources/blob/master/BestPractices.md).

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/powershell/xexchange/432)
<!-- Reviewable:end -->
