### PR TITLE
xExchangeHelper: Fix/workaround for Test-Path error

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 # Change log for xExchange
 
 ## Unreleased
+- Add workaround for buggy Test-Path cmdlet (e.g. if working with mounted ISO files)
 
 ## 1.30.0.0
 

--- a/Modules/xExchangeHelper.psm1
+++ b/Modules/xExchangeHelper.psm1
@@ -468,6 +468,10 @@ function Get-SetupExeVersion
     $version = $null
 
     # Get Exchange setup.exe version
+
+    # Run Get-PSDrive before Test-Path due to buggy Test-Path cmdlet (e.g. if you use an mounted ISO image)
+    Get-PSDrive > $null
+
     if (Test-Path -Path $Path -ErrorAction SilentlyContinue)
     {
         $setupexeVersionInfo = (Get-ChildItem -Path $Path).VersionInfo


### PR DESCRIPTION
#### Pull Request (PR) description
Sometimes the Test-Path cmdlet is a little bit buggy and return false even if the path is available. For example if you mount the Exchange ISO image with Mount-DiskImage, the first Test-Path returns false although setup.exe is accessible. To prevent this, it is helpful to run a Get-PSDrive before running Test-Path the first time. 

#### This Pull Request (PR) fixes the following issues
None

#### Task list

- [x ] Added an entry under the Unreleased section of the change log in the CHANGELOG.md.
      Entry should say what was changed, and how that affects users (if applicable).
- [ ] Resource documentation added/updated in README.md.
- [ ] Resource parameter descriptions added/updated in README.md, schema.mof
      and comment-based help.
- [ ] Comment-based help added/updated.
- [ ] Localization strings added/updated in all localization files as appropriate.
- [ ] Examples appropriately added/updated.
- [ ] Unit tests added/updated. See [DSC Resource Testing Guidelines](https://github.com/PowerShell/DscResources/blob/master/TestsGuidelines.md).
- [ ] Integration tests added/updated (where possible). See [DSC Resource Testing Guidelines](https://github.com/PowerShell/DscResources/blob/master/TestsGuidelines.md).
- [ ] New/changed code adheres to [DSC Resource Style Guidelines](https://github.com/PowerShell/DscResources/blob/master/StyleGuidelines.md) and [Best Practices](https://github.com/PowerShell/DscResources/blob/master/BestPractices.md).

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/powershell/xexchange/433)
<!-- Reviewable:end -->
