### PR TITLE
xExchSendConnector: Fixing ExtendedRight functionality

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,8 +12,8 @@ For older change log history see the [historic changelog](HISTORIC_CHANGELOG.md)
 - xExchange
   - Update CI pipeline files.
   - Fixing xExchSendConnector ExtendedRight functionality by moving the test function
-to the helper module and setting explicit Deny permissions, instead of removing
-the marked as 'Deny' entries.
+  to the helper module and setting explicit Deny permissions, instead of removing
+  the marked as 'Deny' entries.
 
 ## [1.31.0] - 2020-01-27
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,9 @@ For older change log history see the [historic changelog](HISTORIC_CHANGELOG.md)
 
 - xExchange
   - Update CI pipeline files.
+  - Fixing xExchSendConnector ExtendedRight functionality by moving the test function
+to the helper module and setting explicit Deny permissions, instead of removing
+the marked as 'Deny' entries.
 
 ## [1.31.0] - 2020-01-27
 

--- a/Tests/Integration/MSFT_xExchSendConnector.Integration.Tests.ps1
+++ b/Tests/Integration/MSFT_xExchSendConnector.Integration.Tests.ps1
@@ -1,0 +1,132 @@
+<#
+    .SYNOPSIS
+        Automated integration test for MSFT_xExchSendConnector DSC Resource.
+        This test module requires use of credentials.
+        The first run through of the tests will prompt for credentials from the logged on user.
+#>
+
+#region HEADER
+[System.String] $script:moduleRoot = Split-Path -Parent (Split-Path -Parent $PSScriptRoot)
+[System.String] $script:DSCModuleName = 'xExchange'
+[System.String] $script:DSCResourceFriendlyName = 'xExchSendConnector'
+[System.String] $script:DSCResourceName = "MSFT_$($script:DSCResourceFriendlyName)"
+
+Import-Module -Name (Join-Path -Path $script:moduleRoot -ChildPath (Join-Path -Path 'Tests' -ChildPath (Join-Path -Path 'TestHelpers' -ChildPath 'xExchangeTestHelper.psm1'))) -Force
+Import-Module -Name (Join-Path -Path $script:moduleRoot -ChildPath (Join-Path -Path 'Modules' -ChildPath 'xExchangeHelper.psm1')) -Force
+Import-Module -Name (Join-Path -Path $script:moduleRoot -ChildPath (Join-Path -Path 'DSCResources' -ChildPath (Join-Path -Path "$($script:DSCResourceName)" -ChildPath "$($script:DSCResourceName).psm1")))
+
+# Check if Exchange is installed on this machine. If not, we can't run tests
+[System.Boolean] $exchangeInstalled = Test-ExchangeSetupComplete
+
+#endregion HEADER
+
+if ($exchangeInstalled)
+{
+    # Get required credentials to use for the test
+    $shellCredentials = Get-TestCredential
+
+    Describe 'Set and modify a Send Connector' {
+        # Set configuration with default values
+
+        $extendedRightAllowEntries = (
+            New-CimInstance -ClassName MSFT_KeyValuePair -Namespace root/microsoft/Windows/DesiredStateConfiguration  -ClientOnly -Property @{
+                Key   = 'NT AUTHORITY\ANONYMOUS LOGON'
+                Value = 'Ms-Exch-SMTP-Accept-Any-Sender,ms-Exch-Bypass-Anti-Spam'
+            }
+        )
+        $getParams = @{
+            Name          = "DCSTestSendConnector"
+            Credential    = $shellCredentials
+            AddressSpaces = 'SMTP:test.com;1'
+        }
+        $testParams = @{
+            Name                         = "DCSTestSendConnector"
+            Credential                   = $shellCredentials
+            Ensure                       = 'Present'
+            AddressSpaces                = 'SMTP:test.com;1'
+            ExtendedRightAllowEntries    = $extendedRightAllowEntries
+            Comment                      = 'Connector for integration testing'
+            ConnectionInactivityTimeout  = '00:05:00'
+            ConnectorType                = 'Default'
+            #DomainController             = ''
+            DNSRoutingEnabled            = $true
+            DomainSecureEnabled          = $true
+            Enabled                      = $true
+            ErrorPolicies                = 'Default'
+            ForceHELO                    = $true
+            FrontendProxyEnabled         = $false
+            Fqdn                         = 'smtp.local.test'
+            IgnoreSTARTTLS               = $false
+            IsScopedConnector            = $false
+            Port                         = $false
+            ProtocolLoggingLevel         = 'Verbose'
+            RequireTLS                   = $true
+            SmtpMaxMessagesPerConnection = 20
+            SourceTransportServers       = $env:computername
+            UseExternalDNSServersEnabled = $false
+            Usage                        = 'Custom'
+        }
+
+        $expectedGetResults = @{
+            Name                         = "DCSTestSendConnector"
+            Ensure                       = 'Present'
+            ExtendedRightAllowEntries    = $extendedRightAllowEntries
+            AddressSpaces                = 'SMTP:test.com;1'
+            Comment                      = 'Connector for integration testing'
+            ConnectionInactivityTimeout  = '00:05:00'
+            ConnectorType                = 'Default'
+            DNSRoutingEnabled            = $true
+            DomainSecureEnabled          = $true
+            Enabled                      = $true
+            ErrorPolicies                = 'Default'
+            ForceHELO                    = $true
+            FrontendProxyEnabled         = $false
+            Fqdn                         = 'smtp.local.test'
+            IgnoreSTARTTLS               = $false
+            IsCoexistenceConnector       = $false
+            IsScopedConnector            = $false
+            Port                         = $false
+            ProtocolLoggingLevel         = 'Verbose'
+            RequireTLS                   = $true
+            SmtpMaxMessagesPerConnection = 20
+            SourceTransportServers       = $env:computername
+            UseExternalDNSServersEnabled = $false
+        }
+
+        Test-TargetResourceFunctionality -GetParams $getParams -Params $testParams -ContextLabel 'Create Send Connector' -ExpectedGetResults $expectedGetResults
+
+        # Modify configuration
+        $extendedRightDenyEntries = $(New-CimInstance -ClassName MSFT_KeyValuePair -Namespace root/microsoft/Windows/DesiredStateConfiguration `
+                -Property @{Key = "$($env:USERDOMAIN)\Domain Users"; Value = 'ms-Exch-Bypass-Anti-Spam' } -ClientOnly)
+
+        $testParams.ExtendedRightDenyEntries = $extendedRightDenyEntries
+        $expectedGetResults.ExtendedRightDenyEntries = $extendedRightDenyEntries
+
+        Test-TargetResourceFunctionality -GetParams $getParams -Params $testParams -ContextLabel 'Modify Send Connector' -ExpectedGetResults $expectedGetResults
+
+        # Modify configuration
+        $testParams.Ensure = 'Absent'
+        $expectedGetResults = @{
+            Ensure = 'Absent'
+        }
+
+        Test-TargetResourceFunctionality -GetParams $getParams -Params $testParams -ContextLabel 'Remove Send Connector' -ExpectedGetResults $expectedGetResults
+
+        # Try to remove the same Send connector again. This should not cause any errors.
+        $testStartTime = [DateTime]::Now
+
+        Test-TargetResourceFunctionality -GetParams $getParams -Params $testParams -ContextLabel 'Attempt Removal of Already Removed Send Connector' -ExpectedGetResults $expectedGetResults
+
+        Context 'When Get-SendConnector is called and the connector is absent' {
+            It 'Should not cause an error to be logged in the event log' {
+                Get-EventLog -LogName 'MSExchange Management' -After $testStartTime -ErrorAction SilentlyContinue | `
+                    Where-Object -FilterScript { $_.Message -like '*Cmdlet failed. Cmdlet Get-SendConnector, parameters -Identity*' } |`
+                    Should -Be $null
+            }
+        }
+    }
+}
+else
+{
+    Write-Verbose -Message 'Tests in this file require that Exchange is installed to be run.'
+}

--- a/Tests/Integration/MSFT_xExchSendConnector.Integration.Tests.ps1
+++ b/Tests/Integration/MSFT_xExchSendConnector.Integration.Tests.ps1
@@ -39,7 +39,7 @@ if ($exchangeInstalled)
             Credential    = $shellCredentials
             AddressSpaces = 'SMTP:test.com;1'
         }
-        $testParams = @{
+        $testParamsNoDC = @{
             Name                         = "DCSTestSendConnector"
             Credential                   = $shellCredentials
             Ensure                       = 'Present'
@@ -48,7 +48,7 @@ if ($exchangeInstalled)
             Comment                      = 'Connector for integration testing'
             ConnectionInactivityTimeout  = '00:05:00'
             ConnectorType                = 'Default'
-            #DomainController             = ''
+            DomainController             = ''
             DNSRoutingEnabled            = $true
             DomainSecureEnabled          = $true
             Enabled                      = $true

--- a/source/DSCResources/MSFT_xExchSendConnector/MSFT_xExchSendConnector.psm1
+++ b/source/DSCResources/MSFT_xExchSendConnector/MSFT_xExchSendConnector.psm1
@@ -872,7 +872,7 @@ function Test-TargetResource
                 $testResults = $false
             }
 
-            if ($ExtendedRightAllowEntries -and $adPermissions.Deny -contains $false)
+            if ($ExtendedRightAllowEntries)
             {
                 $splat = @{
                     ADPermissions  = $adPermissions
@@ -888,11 +888,7 @@ function Test-TargetResource
                     $testResults = $false
                 }
             }
-            if (-not $ExtendedRightAllowEntries -and $adPermissions -and $adPermissions.Deny -notcontains $false)
-            {
-                return $false
-            }
-            if ($ExtendedRightDenyEntries -and $adPermissions.Deny -contains $true)
+            if ($ExtendedRightDenyEntries)
             {
                 $splat = @{
                     ADPermissions  = $adPermissions
@@ -907,10 +903,6 @@ function Test-TargetResource
                 {
                     $testResults = $false
                 }
-            }
-            if (-not $ExtendedRightDenyEntries -and $adPermissions -and $adPermissions.Deny -contains $true)
-            {
-                return $false
             }
         }
     }
@@ -953,15 +945,11 @@ function Test-ExtendedRightsPresent
             $permissionsFound = $ADPermissions | Where-Object { ($_.User.RawIdentity -eq $Right.Key) -and ($_.ExtendedRights.RawIdentity -eq $Value) }
             if ($null -ne $permissionsFound)
             {
-                if ($Deny -eq $true -and $permissionsFound.Deny -eq $false -or
-                    $Deny -eq $false -and $permissionsFound.Deny -eq $true)
+                if ($Deny -eq $true -and $permissionsFound.Deny.ToBool() -eq $false -or
+                    $Deny -eq $false -and $permissionsFound.Deny.ToBool() -eq $true)
                 {
                     Write-InvalidSettingVerbose -SettingName 'ExtendedRight' -ExpectedValue "User:$($Right.Key) Value:$Value" -ActualValue 'Present' -Verbose:$VerbosePreference
                     return $false
-                }
-                else
-                {
-                    return $true
                 }
             }
             else

--- a/source/DSCResources/MSFT_xExchSendConnector/MSFT_xExchSendConnector.psm1
+++ b/source/DSCResources/MSFT_xExchSendConnector/MSFT_xExchSendConnector.psm1
@@ -380,6 +380,10 @@ function Set-TargetResource
 
         Set-EmptyStringParamsToNull -PSBoundParametersIn $PSBoundParameters
 
+        if ($null -eq $DomainController)
+        {
+            $PSBoundParameters['DomainController'] = Get-DomainController | Select-Object -First 1 | ForEach-Object -MemberName 'DnsHostName'
+        }
         # We need to create the new connector
         if ($connector['Ensure'] -eq 'Absent')
         {
@@ -394,7 +398,7 @@ function Set-TargetResource
                 {
                     foreach ($Value in $($ExtendedRightAllowEntry.Value.Split(',')))
                     {
-                        Add-ADPermission -Identity $Name -User $ExtendedRightAllowEntry.Key -ExtendedRights $Value -DomainController $DomainController
+                        Add-ADPermission -Identity $Name -User $ExtendedRightAllowEntry.Key -ExtendedRights $Value -DomainController $PSBoundParameters['DomainController']
                     }
                 }
             }
@@ -405,7 +409,7 @@ function Set-TargetResource
                 {
                     foreach ($Value in $($ExtendedRightDenyEntry.Value.Split(',')))
                     {
-                        Add-ADPermission -Identity $Name -User $ExtendedRightDenyEntry.Key -ExtendedRights $Value -Deny -Confirm:$false -DomainController $DomainController
+                        Add-ADPermission -Identity $Name -User $ExtendedRightDenyEntry.Key -ExtendedRights $Value -Deny -Confirm:$false -DomainController $PSBoundParameters['DomainController']
                     }
                 }
             }

--- a/source/DSCResources/MSFT_xExchSendConnector/MSFT_xExchSendConnector.psm1
+++ b/source/DSCResources/MSFT_xExchSendConnector/MSFT_xExchSendConnector.psm1
@@ -40,7 +40,6 @@ function Get-TargetResource
 
     if ($null -ne $connector)
     {
-
         $adPermissions = Get-ADExtendedPermissions -Identity $Name
 
         $returnValue = @{

--- a/source/DSCResources/MSFT_xExchSendConnector/MSFT_xExchSendConnector.psm1
+++ b/source/DSCResources/MSFT_xExchSendConnector/MSFT_xExchSendConnector.psm1
@@ -332,11 +332,6 @@ function Set-TargetResource
 
     $connector = Get-TargetResource -Name $Name -Credential $Credential -AddressSpaces $AddressSpaces
 
-    if (-not $DomainController)
-    {
-        $PSBoundParameters['DomainController'] = Get-DomainController | Select-Object -First 1 | ForEach-Object -MemberName 'DnsHostName'
-    }
-
     if ($Ensure -eq 'Absent')
     {
         Write-Verbose -Message "Removing send connector $Name."
@@ -357,6 +352,12 @@ function Set-TargetResource
             Write-Verbose -Message "Creating send connector $Name."
 
             New-SendConnector @PSBoundParameters
+
+            if ($ExtendedRightAllowEntries -or $ExtendedRightDenyEntries)
+            {
+                # Setting some sleep period to allow intra-site replication
+                Start-Sleep -Seconds 180
+            }
 
             if ($ExtendedRightAllowEntries)
             {

--- a/source/Modules/xExchangeHelper/xExchangeHelper.psd1
+++ b/source/Modules/xExchangeHelper/xExchangeHelper.psd1
@@ -122,7 +122,10 @@
         'Assert-ExchangeSetupArgumentsComplete',
         'Get-StringFromHashtable',
         'Get-DomainDNFromFQDN',
-        'Set-DSCMachineStatus'
+        'Set-DSCMachineStatus',
+        'Test-ExtendedRightsPresent',
+        'Test-ExtendedRights',
+        'Get-ADExtendedPermissions'
     )
 
     # Cmdlets to export from this module, for best performance, do not use wildcards and do not delete the entry, use an empty array if there are no cmdlets to export.

--- a/source/Modules/xExchangeHelper/xExchangeHelper.psm1
+++ b/source/Modules/xExchangeHelper/xExchangeHelper.psm1
@@ -2571,7 +2571,7 @@ function Set-DSCMachineStatus
 #>
 function Test-ExtendedRightsPresent
 {
-    [cmdletbinding()]
+    [CmdletBinding()]
     [OutputType([System.Boolean])]
     param
     (

--- a/source/Modules/xExchangeHelper/xExchangeHelper.psm1
+++ b/source/Modules/xExchangeHelper/xExchangeHelper.psm1
@@ -86,6 +86,7 @@ function Get-RemoteExchangeSession
     }
     else # Import the session globally
     {
+        $CommandsToLoad.Add('Get-DomainController')
         Import-RemoteExchangeSession -Session $session -CommandsToLoad $CommandsToLoad -Verbose:([System.Management.Automation.ActionPreference]::SilentlyContinue)
     }
 }

--- a/source/xExchange.psd1
+++ b/source/xExchange.psd1
@@ -77,7 +77,10 @@
         'Assert-ExchangeSetupArgumentsComplete',
         'Get-StringFromHashtable',
         'Get-DomainDNFromFQDN',
-        'Set-DSCMachineStatus'
+        'Set-DSCMachineStatus',
+        'Test-ExtendedRightsPresent',
+        'Test-ExtendedRights',
+        'Get-ADExtendedPermissions'
     )
 
     # Cmdlets to export from this module

--- a/tests/Integration/MSFT_xExchDatabaseAvailabilityGroup.Integration.Tests.ps1
+++ b/tests/Integration/MSFT_xExchDatabaseAvailabilityGroup.Integration.Tests.ps1
@@ -15,9 +15,9 @@
 [System.String] $script:DSCResourceFriendlyName = 'xExchDatabaseAvailabilityGroup'
 [System.String] $script:DSCResourceName = "MSFT_$($script:DSCResourceFriendlyName)"
 
-Import-Module -Name (Join-Path -Path $script:moduleRoot -ChildPath (Join-Path -Path 'Tests' -ChildPath (Join-Path -Path 'TestHelpers' -ChildPath 'xExchangeTestHelper.psm1'))) -Force
-Import-Module -Name (Join-Path -Path $script:moduleRoot -ChildPath (Join-Path -Path 'Modules' -ChildPath 'xExchangeHelper.psm1')) -Force
-Import-Module -Name (Join-Path -Path $script:moduleRoot -ChildPath (Join-Path -Path 'DSCResources' -ChildPath (Join-Path -Path "$($script:DSCResourceName)" -ChildPath "$($script:DSCResourceName).psm1")))
+Import-Module -Name (Join-Path -Path $script:moduleRoot -ChildPath (Join-Path -Path 'tests' -ChildPath (Join-Path -Path 'TestHelpers' -ChildPath 'xExchangeTestHelper.psm1'))) -Force
+Import-Module -Name (Join-Path -Path $script:moduleRoot -ChildPath (Join-Path -Path 'source' -ChildPath (Join-Path -Path 'Modules' -ChildPath 'xExchangeHelper\xExchangeHelper.psd1'))) -Force
+Import-Module -Name (Join-Path -Path $script:moduleRoot -ChildPath (Join-Path -Path 'source' -ChildPath (Join-Path -Path 'DSCResources' -ChildPath (Join-Path -Path "$($script:DSCResourceName)" -ChildPath "$($script:DSCResourceName).psm1"))))
 
 # Check if Exchange is installed on this machine. If not, we can't run tests
 [System.Boolean] $exchangeInstalled = Test-ExchangeSetupComplete

--- a/tests/TestHelpers/xExchangeTestHelper.psm1
+++ b/tests/TestHelpers/xExchangeTestHelper.psm1
@@ -757,13 +757,13 @@ function Test-CimArrayContainsSubArray
         {
             if (-not (Compare-Object -DifferenceObject $subItem -ReferenceObject $item -Property Key, Value))
             {
-                #found a match, skip to next $subItem
+                # Found a match, skip to next $subItem
                 $equalFound = $true
                 break
             }
             if (Test-ArrayElementsInSecondArray -Array1 $subItem.value.Split(',') -Array2 $item.Value.Split(',') -IgnoreCase)
             {
-                #found a match, skip to next $subItem
+                # Found a match, skip to next $subItem
                 $equalFound = $true
                 break
             }

--- a/tests/Unit/MSFT_xExchImapSettings.tests.ps1
+++ b/tests/Unit/MSFT_xExchImapSettings.tests.ps1
@@ -53,7 +53,6 @@ try
             SuppressReadReceipt               = [System.Boolean] $false
             UnencryptedOrTLSBindings          = [System.String[]] @()
         }
-
         Describe 'MSFT_xExchImapSettings\Get-TargetResource' -Tag 'Get' {
             AfterEach {
                 Assert-VerifiableMock

--- a/tests/Unit/MSFT_xExchImapSettings.tests.ps1
+++ b/tests/Unit/MSFT_xExchImapSettings.tests.ps1
@@ -169,6 +169,24 @@ try
                 }
             }
         }
+
+        Describe 'MSFT_xExchImapSettings\Get-ImapSettingsInternal' -Tag 'Helper' {
+            # Override Exchange cmdlets
+            function Get-ImapSettings { }
+
+            AfterEach {
+                Assert-VerifiableMock
+            }
+
+            Context 'When Get-ImapSettingsInternal is called' {
+                It 'Should call expected functions' {
+                    Mock -CommandName Get-ImapSettings -Verifiable -MockWith { return $commonImapSettingsStandardOutput }
+                    Mock -CommandName Restart-Service -Verifiable
+
+                    Get-ImapSettingsInternal @commonTargetResourceParams
+                }
+            }
+        }
     }
 }
 finally

--- a/tests/Unit/MSFT_xExchImapSettings.tests.ps1
+++ b/tests/Unit/MSFT_xExchImapSettings.tests.ps1
@@ -181,7 +181,6 @@ try
             Context 'When Get-ImapSettingsInternal is called' {
                 It 'Should call expected functions' {
                     Mock -CommandName Get-ImapSettings -Verifiable -MockWith { return $commonImapSettingsStandardOutput }
-                    Mock -CommandName Restart-Service -Verifiable
 
                     Get-ImapSettingsInternal @commonTargetResourceParams
                 }

--- a/tests/Unit/MSFT_xExchImapSettings.tests.ps1
+++ b/tests/Unit/MSFT_xExchImapSettings.tests.ps1
@@ -53,6 +53,7 @@ try
             SuppressReadReceipt               = [System.Boolean] $false
             UnencryptedOrTLSBindings          = [System.String[]] @()
         }
+
         Describe 'MSFT_xExchImapSettings\Get-TargetResource' -Tag 'Get' {
             AfterEach {
                 Assert-VerifiableMock

--- a/tests/Unit/MSFT_xExchSendConnector.tests.ps1
+++ b/tests/Unit/MSFT_xExchSendConnector.tests.ps1
@@ -17,6 +17,7 @@ try
     InModuleScope $script:DSCResourceName {
         function Get-ADPermission
         {
+
         }
         function Add-ADPermission
         {
@@ -66,7 +67,7 @@ try
             }
 
             $getSendConnectorOutput = @{
-                Name                = 'MySendConnector'
+                Identity            = 'MySendConnector'
                 AddressSpaces       = 'contoso.com'
                 DNSRoutingEnabled   = $true
                 DomainSecureEnabled = $true
@@ -80,15 +81,15 @@ try
 
             Context 'When Get-TargetResource is called and resource is present' {
                 Mock -CommandName Get-SendConnector -Verifiable -MockWith { return [PSCustomObject] $getSendConnectorOutput }
-                Mock -CommandName Get-ADPermission
+
+                Mock -CommandName Get-ADPermission -ModuleName 'xExchangeHelper'
 
                 Test-CommonGetTargetResourceFunctionality -GetTargetResourceParams $getTargetResourceParams
             }
-
             Context 'When resource is not present' {
                 It 'Should return Absent' {
                     Mock -CommandName Get-SendConnector -Verifiable
-                    Mock -CommandName Get-ADPermission
+                    Mock -CommandName Get-ADPermission -ModuleName 'xExchangeHelper'
 
                     $result = Get-TargetResource @getTargetResourceParams
                     $result['Ensure'] | Should -be 'Absent'
@@ -97,6 +98,7 @@ try
             Context 'When resource is present' {
                 It 'When Name matches' {
                     Mock -CommandName Get-SendConnector -MockWith { $getSendConnectorOutput } -Verifiable
+                    Mock -CommandName Get-ADPermission -ModuleName 'xExchangeHelper'
 
                     $result = Get-TargetResource @getTargetResourceParams
                     $result['Ensure'] | Should -Be 'Present'
@@ -109,6 +111,7 @@ try
                         'SMTP:tailspintoys.com; 1'
                     )
 
+                    Mock -CommandName Get-ADPermission -ModuleName 'xExchangeHelper'
                     Mock -CommandName Get-SendConnector -MockWith { $getSendConnectorOutput } -Verifiable
 
                     $result = Get-TargetResource @getTargetResourceParams
@@ -116,59 +119,59 @@ try
                 }
 
                 Context 'Extended rights are present' {
-                    $ADPermissions = @()
-                    $permission += [PSCustomObject] @{
-                        IsInherited    = $false
-                        User           = [PSCustomObject] @{
-                            RawIdentity = 'User1Allow'
-                        }
-                        Deny           = $false
-                        ExtendedRights = [PSCustomObject] @{
-                            RawIdentity = 'ms-Exch-SMTP-Accept-Any-Recipient'
-                        }
-                    }
-                    $ADPermissions += $permission
-
-                    $permission = [PSCustomObject] @{
-                        IsInherited    = $false
-                        User           = [PSCustomObject] @{
-                            RawIdentity = 'User1Allow'
-                        }
-                        Deny           = $false
-                        ExtendedRights = [PSCustomObject] @{
-                            RawIdentity = 'ms-Exch-SMTP-Accept-Any-Sender'
-                        }
-                    }
-                    $ADPermissions += $permission
-
-                    $permission = [PSCustomObject] @{
-                        IsInherited    = $false
-                        User           = [PSCustomObject] @{
-                            RawIdentity = 'User2Deny'
-                        }
-                        Deny           = $true
-                        ExtendedRights = [PSCustomObject] @{
-                            RawIdentity = 'ms-Exch-SMTP-Accept-Any-Recipient'
-                        }
-                    }
-                    $ADPermissions += $permission
-
-                    $permission = [PSCustomObject] @{
-                        IsInherited    = $false
-                        User           = [PSCustomObject] @{
-                            RawIdentity = 'User2Deny'
-                        }
-                        Deny           = $true
-                        ExtendedRights = [PSCustomObject] @{
-                            RawIdentity = 'ms-Exch-SMTP-Accept-Any-Sender'
-                        }
-                    }
-                    $ADPermissions += $permission
-
                     Mock -CommandName Get-SendConnector -MockWith { $getSendConnectorOutput } -Verifiable
                     Mock -CommandName Get-ADPermission -MockWith {
+                        $ADPermissions = @()
+                        $permission += [PSCustomObject] @{
+                            IsInherited    = $false
+                            User           = [PSCustomObject] @{
+                                RawIdentity = 'User1Allow'
+                            }
+                            Deny           = $false
+                            ExtendedRights = [PSCustomObject] @{
+                                RawIdentity = 'ms-Exch-SMTP-Accept-Any-Recipient'
+                            }
+                        }
+                        $ADPermissions += $permission
+
+                        $permission = [PSCustomObject] @{
+                            IsInherited    = $false
+                            User           = [PSCustomObject] @{
+                                RawIdentity = 'User1Allow'
+                            }
+                            Deny           = $false
+                            ExtendedRights = [PSCustomObject] @{
+                                RawIdentity = 'ms-Exch-SMTP-Accept-Any-Sender'
+                            }
+                        }
+                        $ADPermissions += $permission
+
+                        $permission = [PSCustomObject] @{
+                            IsInherited    = $false
+                            User           = [PSCustomObject] @{
+                                RawIdentity = 'User2Deny'
+                            }
+                            Deny           = $true
+                            ExtendedRights = [PSCustomObject] @{
+                                RawIdentity = 'ms-Exch-SMTP-Accept-Any-Recipient'
+                            }
+                        }
+                        $ADPermissions += $permission
+
+                        $permission = [PSCustomObject] @{
+                            IsInherited    = $false
+                            User           = [PSCustomObject] @{
+                                RawIdentity = 'User2Deny'
+                            }
+                            Deny           = $true
+                            ExtendedRights = [PSCustomObject] @{
+                                RawIdentity = 'ms-Exch-SMTP-Accept-Any-Sender'
+                            }
+                        }
+                        $ADPermissions += $permission
+
                         return $ADPermissions
-                    }
+                    } -ModuleName 'xExchangeHelper'
 
                     It 'Should yield the correct pemissions' {
                         $result = Get-TargetResource @getTargetResourceParams
@@ -206,6 +209,7 @@ try
                 $getSendConnectorOutput = @{
                     Ensure = 'Present'
                 }
+
                 Mock -CommandName Get-TargetResource -MockWith { return $getSendConnectorOutput }
 
                 Context 'When Absent is specified' {
@@ -294,7 +298,7 @@ try
             Context 'When resource exists' {
 
                 $getSendConnectorOutput = @{
-                    Name                = 'MySendConnector'
+                    Identity            = 'MySendConnector'
                     AddressSpaces       = @('contoso.com' , 'SMTP:tailspintoys.com:1')
                     DNSRoutingEnabled   = $true
                     DomainSecureEnabled = $true

--- a/tests/Unit/MSFT_xExchSendConnector.tests.ps1
+++ b/tests/Unit/MSFT_xExchSendConnector.tests.ps1
@@ -342,7 +342,7 @@ try
                         User           = [PSCustomObject] @{
                             RawIdentity = 'User1Allow'
                         }
-                        Deny           = $false
+                        Deny           = [System.Management.Automation.SwitchParameter]::new($false)
                         ExtendedRights = [PSCustomObject] @{
                             RawIdentity = 'ms-Exch-SMTP-Accept-Any-Recipient'
                         }
@@ -354,7 +354,7 @@ try
                         User           = [PSCustomObject] @{
                             RawIdentity = 'User1Allow'
                         }
-                        Deny           = $false
+                        Deny           = [System.Management.Automation.SwitchParameter]::new($false)
                         ExtendedRights = [PSCustomObject] @{
                             RawIdentity = 'ms-Exch-SMTP-Accept-Any-Sender'
                         }
@@ -366,7 +366,7 @@ try
                         User           = [PSCustomObject] @{
                             RawIdentity = 'User2Deny'
                         }
-                        Deny           = $true
+                        Deny           = [System.Management.Automation.SwitchParameter]::new($true)
                         ExtendedRights = [PSCustomObject] @{
                             RawIdentity = 'ms-Exch-SMTP-Accept-Any-Recipient'
                         }
@@ -378,7 +378,7 @@ try
                         User           = [PSCustomObject] @{
                             RawIdentity = 'User2Deny'
                         }
-                        Deny           = $true
+                        Deny           = [System.Management.Automation.SwitchParameter]::new($true)
                         ExtendedRights = [PSCustomObject] @{
                             RawIdentity = 'ms-Exch-SMTP-Accept-Any-Sender'
                         }
@@ -394,7 +394,7 @@ try
                             $TestTargetResourceParamsFalse['ExtendedRightAllowEntries'] = (
                                 New-CimInstance -ClassName 'MSFT_KeyValuePair' -Property @{
                                     key   = 'User1Allow'
-                                    value = 'ms-Exch-SMTP-Accept-Any-Recipient,ms-Exch-SMTP-Accept-Any-Sender'
+                                    value = 'ms-Exch-SMTP-Accept-Any-Recipient,ms-Exch-SMTP-Accept-Authoritative-Domain-Sender'
                                 } -ClientOnly
                             )
 

--- a/tests/Unit/MSFT_xExchSendConnector.tests.ps1
+++ b/tests/Unit/MSFT_xExchSendConnector.tests.ps1
@@ -402,6 +402,7 @@ try
                             $TestTargetResourceParamsFalse['ExtendedRightAllowEntries'] = (
                                 New-CimInstance -ClassName 'MSFT_KeyValuePair' -Property @{
                                     key   = 'User1Allow'
+                                    # Picking 2 random permissions to test with
                                     value = 'ms-Exch-SMTP-Accept-Any-Recipient,ms-Exch-SMTP-Accept-Authoritative-Domain-Sender'
                                 } -ClientOnly
                             )

--- a/tests/Unit/MSFT_xExchSendConnector.tests.ps1
+++ b/tests/Unit/MSFT_xExchSendConnector.tests.ps1
@@ -19,6 +19,10 @@ try
         {
 
         }
+        function Get-DomainController
+        {
+
+        }
         function Add-ADPermission
         {
             param(


### PR DESCRIPTION
#### Pull Request (PR) description
While rewriting the xExchReceiveConnector I noticed that setting the extended rights was kind of buggy. This PR applies the same logic as in xExchReceiveConnector.

#### This Pull Request (PR) fixes the following issues
None.

#### Task list
- [x] Added an entry under the Unreleased section of the change log in the CHANGELOG.md.
      Entry should say what was changed, and how that affects users (if applicable).
- [ ] Resource documentation added/updated in README.md.
- [ ] Resource parameter descriptions added/updated in README.md, schema.mof
      and comment-based help.
- [ ] Comment-based help added/updated.
- [ ] Localization strings added/updated in all localization files as appropriate.
- [ ] Examples appropriately added/updated.
- [ ] Unit tests added/updated. See [DSC Resource Testing Guidelines](https://github.com/PowerShell/DscResources/blob/master/TestsGuidelines.md).
- [x] Integration tests added/updated (where possible). See [DSC Resource Testing Guidelines](https://github.com/PowerShell/DscResources/blob/master/TestsGuidelines.md).
- [x] New/changed code adheres to [DSC Resource Style Guidelines](https://github.com/PowerShell/DscResources/blob/master/StyleGuidelines.md) and [Best Practices](https://github.com/PowerShell/DscResources/blob/master/BestPractices.md).

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dsccommunity/xexchange/438)
<!-- Reviewable:end -->
