### PR TITLE
xExchange: Export Remote Exchange module to temp

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,7 @@ For older change log history see the [historic changelog](HISTORIC_CHANGELOG.md)
 ## [Unreleased]
 
 - xExchange
-  - A remote implicing module with all Exchange cmdlets will be created under 
+  - A remote implicing module with all Exchange cmdlets will be created under
   $env:Temp and reused every time DSC check runs, instead of creating a new
   module every time.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,11 @@ For older change log history see the [historic changelog](HISTORIC_CHANGELOG.md)
 
 ## [Unreleased]
 
+- xExchange
+  - A remote implicing module with all Exchange cmdlets will be created under 
+  $env:Temp and reused every time DSC check runs, instead of creating a new
+  module every time.
+
 ### Changed
 
 - xExchange

--- a/source/DSCResources/MSFT_xExchPowershellVirtualDirectory/MSFT_xExchPowerShellVirtualDirectory.psm1
+++ b/source/DSCResources/MSFT_xExchPowershellVirtualDirectory/MSFT_xExchPowerShellVirtualDirectory.psm1
@@ -135,7 +135,7 @@ function Set-TargetResource
     if ($AllowServiceRestart -eq $true)
     {
         # Remove existing PS sessions, as we're about to break them
-        Remove-RemoteExchangeSession -Verbose:$VerbosePreference
+        Remove-RemoteExchangeModule -Verbose:$VerbosePreference
 
         Write-Verbose -Message 'Recycling MSExchangePowerShellAppPool and MSExchangePowerShellFrontEndAppPool'
 

--- a/source/Modules/xExchangeHelper/xExchangeHelper.psd1
+++ b/source/Modules/xExchangeHelper/xExchangeHelper.psd1
@@ -12,7 +12,7 @@
     RootModule        = 'xExchangeHelper.psm1'
 
     # Version number of this module.
-    ModuleVersion     = '1.0.0'
+    ModuleVersion     = '1.0.1'
 
     # Supported PSEditions
     # CompatiblePSEditions = @()
@@ -74,7 +74,7 @@
         'Get-RemoteExchangeSession',
         'New-RemoteExchangeSession',
         'Import-RemoteExchangeSession',
-        'Remove-RemoteExchangeSession',
+        'Remove-RemoteExchangeModule',
         'Test-ExchangePresent',
         'Get-ExchangeVersionYear',
         'Get-ExchangeUninstallKey'

--- a/source/Modules/xExchangeHelper/xExchangeHelper.psd1
+++ b/source/Modules/xExchangeHelper/xExchangeHelper.psd1
@@ -73,7 +73,7 @@
         'Get-ExistingRemoteExchangeSession',
         'Get-RemoteExchangeSession',
         'New-RemoteExchangeSession',
-        'Import-RemoteExchangeSession',
+        'Import-RemoteExchangeModule',
         'Remove-RemoteExchangeModule',
         'Test-ExchangePresent',
         'Get-ExchangeVersionYear',

--- a/source/Modules/xExchangeHelper/xExchangeHelper.psm1
+++ b/source/Modules/xExchangeHelper/xExchangeHelper.psm1
@@ -88,7 +88,14 @@ function Get-RemoteExchangeSession
         }
         else # Import the session globally
         {
-            Import-RemoteExchangeModule -Session $session -Verbose:([System.Management.Automation.ActionPreference]::SilentlyContinue) -CommandsToLoad $CommandsToLoad
+            if ($CommandsToLoad)
+            {
+                $PSDefaultParameterValues = @{
+                    "Import-RemoteExchangeModule:CommandsToLoad" = $CommandsToLoad
+                }
+            }
+
+            Import-RemoteExchangeModule -Session $session -Verbose:$VerbosePreference
         }
     }
     else
@@ -99,8 +106,14 @@ function Get-RemoteExchangeSession
         {
             $session = New-RemoteExchangeSession -Credential $Credential -Verbose:$VerbosePreference
         }
+        if ($CommandsToLoad)
+        {
+            $PSDefaultParameterValues = @{
+                "Import-Module:Function" = $CommandsToLoad
+            }
+        }
 
-        Import-Module $env:Temp\DSCExchangeModule\DSCExchangeModule.psm1 -ArgumentList $session -Global -DisableNameChecking -Function $CommandsToLoad -Force
+        Import-Module $env:Temp\DSCExchangeModule\DSCExchangeModule.psm1 -ArgumentList $session -Global -DisableNameChecking -Force
     }
 }
 

--- a/source/Modules/xExchangeHelper/xExchangeHelper.psm1
+++ b/source/Modules/xExchangeHelper/xExchangeHelper.psm1
@@ -1,3 +1,6 @@
+$script:DSCExchangeModuleName = 'DSCExchangeModule'
+$script:DSCExchangeModulePath = "$env:Temp\DSCExchangeModuleName"
+
 <#
     .SYNOPSIS
         Gets the existing Remote PowerShell session to Exchange, if it exists
@@ -73,8 +76,8 @@ function Get-RemoteExchangeSession
     #See if there is already an Exchange Session
     $session = Get-ExistingRemoteExchangeSession -Verbose:$VerbosePreference
 
-    # See if the Exchange Module is alredy export to $env:Temp
-    $exportedModule = Test-Path -Path "$env:TEMP\DSCExchangeModule"
+    # See if the Exchange Module is already exported to $env:Temp
+    $exportedModule = Test-Path -Path $script:DSCExchangeModulePath
 
     # If the exported Exchange module does not exist, create a session and export it
     if ($exportedModule -eq $false)
@@ -91,7 +94,7 @@ function Get-RemoteExchangeSession
             if ($CommandsToLoad)
             {
                 $PSDefaultParameterValues = @{
-                    "Import-RemoteExchangeModule:CommandsToLoad" = $CommandsToLoad
+                    'Import-RemoteExchangeModule:CommandsToLoad' = $CommandsToLoad
                 }
             }
 
@@ -100,7 +103,7 @@ function Get-RemoteExchangeSession
     }
     else
     {
-        Write-Verbose -Message 'Importing the DSCExchangeModule.'
+        Write-Verbose -Message 'Importing the xExchange Remote PowerShell Module.'
 
         if ($null -eq $session)
         {
@@ -109,11 +112,11 @@ function Get-RemoteExchangeSession
         if ($CommandsToLoad)
         {
             $PSDefaultParameterValues = @{
-                "Import-Module:Function" = $CommandsToLoad
+                'Import-Module:Function' = $CommandsToLoad
             }
         }
 
-        Import-Module $env:Temp\DSCExchangeModule\DSCExchangeModule.psm1 -ArgumentList $session -Global -DisableNameChecking -Force
+        Import-Module $script:DSCExchangeModulePath\$script:DSCExchangeModuleName.psm1 -ArgumentList $session -Global -DisableNameChecking -Force
     }
 }
 
@@ -217,8 +220,8 @@ function Import-RemoteExchangeModule
         $CommandsToLoad = @('*')
     )
 
-    Export-PSSession -Session $Session -OutputModule $env:Temp\DSCExchangeModule
-    Import-Module $env:Temp\DSCExchangeModule -Global -DisableNameChecking -Function $CommandsToLoad
+    Export-PSSession -Session $Session -OutputModule $script:DSCExchangeModulePath
+    Import-Module $script:DSCExchangeModulePath -Global -DisableNameChecking -Function $CommandsToLoad
 }
 
 <#
@@ -231,7 +234,7 @@ function Remove-RemoteExchangeModule
     [CmdletBinding()]
     param ()
 
-    Remove-Module -Name 'DSCExchangeModule' -Force
+    Remove-Module -Name $script:DSCExchangeModuleName -Force
 }
 
 <#

--- a/source/Modules/xExchangeHelper/xExchangeHelper.psm1
+++ b/source/Modules/xExchangeHelper/xExchangeHelper.psm1
@@ -116,7 +116,7 @@ function Get-RemoteExchangeSession
             }
         }
 
-        Import-Module $script:DSCExchangeModulePath\$script:DSCExchangeModuleName.psm1 -ArgumentList $session -Global -DisableNameChecking -Force
+        Import-Module -Name $script:DSCExchangeModulePath\$script:DSCExchangeModuleName.psm1 -ArgumentList $session -Global -DisableNameChecking -Force
     }
 }
 
@@ -221,7 +221,7 @@ function Import-RemoteExchangeModule
     )
 
     Export-PSSession -Session $Session -OutputModule $script:DSCExchangeModulePath
-    Import-Module $script:DSCExchangeModulePath -Global -DisableNameChecking -Function $CommandsToLoad
+    Import-Module -Name $script:DSCExchangeModulePath -Global -DisableNameChecking -Function $CommandsToLoad
 }
 
 <#

--- a/source/xExchange.psd1
+++ b/source/xExchange.psd1
@@ -29,7 +29,7 @@
         'Get-RemoteExchangeSession',
         'New-RemoteExchangeSession',
         'Import-RemoteExchangeSession',
-        'Remove-RemoteExchangeSession',
+        'Remove-RemoteExchangeModule',
         'Test-ExchangePresent',
         'Get-ExchangeVersionYear',
         'Get-ExchangeUninstallKey'

--- a/tests/Integration/MSFT_xExchExchangeServer.Integration.Tests.ps1
+++ b/tests/Integration/MSFT_xExchExchangeServer.Integration.Tests.ps1
@@ -45,7 +45,7 @@ function Clear-ExchDscServerADProperty
         $Property
     )
 
-    Get-ADObject -SearchBase "$($exchangeServerDN)" -Filter {ObjectClass -eq 'msExchExchangeServer'} | Where-Object -FilterScript {
+    Get-ADObject -SearchBase "$($exchangeServerDN)" -Filter { ObjectClass -eq 'msExchExchangeServer' } | Where-Object -FilterScript {
         $_.ObjectClass -eq 'msExchExchangeServer'
     } | Set-ADObject -Clear "$($Property)"
 }
@@ -98,7 +98,7 @@ if ($null -ne $adModule)
             }
 
             # Remove our remote Exchange session so as not to interfere with actual Integration testing
-            Remove-RemoteExchangeSession
+            Remove-RemoteExchangeModule
         }
 
         # Get the product key to use for testing
@@ -107,7 +107,7 @@ if ($null -ne $adModule)
             $productKey = Read-Host -Prompt 'Enter the product key to license Exchange with, or press ENTER to skip testing the licensing of the server.'
         }
 
-        $testDC = [System.Net.Dns]::GetHostByName($env:LOGONSERVER.Replace('\\','')).HostName
+        $testDC = [System.Net.Dns]::GetHostByName($env:LOGONSERVER.Replace('\\', '')).HostName
 
         $serverVersion = Get-ExchangeVersionYear
 
@@ -126,7 +126,7 @@ if ($null -ne $adModule)
             }
 
             $expectedGetResults = @{
-                Identity = $env:COMPUTERNAME
+                Identity                        = $env:COMPUTERNAME
                 ErrorReportingEnabled           = $false
                 InternetWebProxy                = ''
                 MonitoringGroup                 = ''
@@ -149,8 +149,8 @@ if ($null -ne $adModule)
 
             # Now do tests
             Test-TargetResourceFunctionality -Params $testParams `
-                                             -ContextLabel 'Standard xExchExchangeServer tests' `
-                                             -ExpectedGetResults $expectedGetResults
+                -ContextLabel 'Standard xExchExchangeServer tests' `
+                -ExpectedGetResults $expectedGetResults
 
             # Alter a number of parameters
             $testParams.InternetWebProxy = $expectedGetResults.InternetWebProxy = 'http://someproxy.local/'
@@ -176,8 +176,8 @@ if ($null -ne $adModule)
 
             # Re-run tests
             Test-TargetResourceFunctionality -Params $testParams `
-                                             -ContextLabel 'Altered xExchExchangeServer tests' `
-                                             -ExpectedGetResults $expectedGetResults
+                -ContextLabel 'Altered xExchExchangeServer tests' `
+                -ExpectedGetResults $expectedGetResults
 
             # Try licensing server with AllowServiceRestart set to True
             Clear-PropsForExchDscServer
@@ -187,8 +187,8 @@ if ($null -ne $adModule)
 
             # Re-run tests
             Test-TargetResourceFunctionality -Params $testParams `
-                                             -ContextLabel 'Service restart after licensing tests' `
-                                             -ExpectedGetResults $expectedGetResults
+                -ContextLabel 'Service restart after licensing tests' `
+                -ExpectedGetResults $expectedGetResults
         }
     }
     else

--- a/tests/Integration/MSFT_xExchMailboxDatabase.Integration.Tests.ps1
+++ b/tests/Integration/MSFT_xExchMailboxDatabase.Integration.Tests.ps1
@@ -43,14 +43,14 @@ function Initialize-ExchDscDatabase
         $_.Name -like "$($Database)"
     } | Remove-MailboxDatabase -Confirm:$false
 
-    Get-ChildItem -LiteralPath "C:\Program Files\Microsoft\Exchange Server\V15\Mailbox\$($Database)" -ErrorAction SilentlyContinue | Remove-Item -Recurse -Force -Confirm:$false -ErrorAction SilentlyContinue
+Get-ChildItem -LiteralPath "C:\Program Files\Microsoft\Exchange Server\V15\Mailbox\$($Database)" -ErrorAction SilentlyContinue | Remove-Item -Recurse -Force -Confirm:$false -ErrorAction SilentlyContinue
 
-    if ($null -ne (Get-MailboxDatabase | Where-Object {$_.Name -like "$($Database)"}))
-    {
-        throw 'Failed to cleanup test database'
-    }
+if ($null -ne (Get-MailboxDatabase | Where-Object { $_.Name -like "$($Database)" }))
+{
+    throw 'Failed to cleanup test database'
+}
 
-    Write-Verbose -Message 'Finished cleaning up test database'
+Write-Verbose -Message 'Finished cleaning up test database'
 }
 
 if ($exchangeInstalled)
@@ -70,81 +70,81 @@ if ($exchangeInstalled)
     # Get Test Mailbox Information
     $testMailbox = Get-DSCTestMailbox -Verbose
     $testMailboxADObjectIDString = ([Microsoft.Exchange.Data.Directory.ADObjectId]::ParseDnOrGuid($testMailbox.DistinguishedName)).ToString()
-    $testMailboxSecondaryAddress = ($testMailbox.EmailAddresses | Where-Object {$_.IsPrimaryAddress -eq $false -and $_.Prefix -like 'SMTP'} | Select-Object -First 1).AddressString
+    $testMailboxSecondaryAddress = ($testMailbox.EmailAddresses | Where-Object { $_.IsPrimaryAddress -eq $false -and $_.Prefix -like 'SMTP' } | Select-Object -First 1).AddressString
 
     # Remove our remote Exchange session so as not to interfere with actual Integration testing
-    Remove-RemoteExchangeSession
+    Remove-RemoteExchangeModule
 
     Describe 'Test Creating a DB and Setting Properties with xExchMailboxDatabase' {
         # First create and set properties on a test database
         $testParams = @{
-            Name = $TestDBName
-            Credential = $shellCredentials
-            Server = $env:COMPUTERNAME
-            EdbFilePath = "C:\Program Files\Microsoft\Exchange Server\V15\Mailbox\$($TestDBName)\$($TestDBName).edb"
-            LogFolderPath = "C:\Program Files\Microsoft\Exchange Server\V15\Mailbox\$($TestDBName)"
-            AllowFileRestore = $true
-            AllowServiceRestart = $true
-            AutoDagExcludeFromMonitoring = $true
+            Name                          = $TestDBName
+            Credential                    = $shellCredentials
+            Server                        = $env:COMPUTERNAME
+            EdbFilePath                   = "C:\Program Files\Microsoft\Exchange Server\V15\Mailbox\$($TestDBName)\$($TestDBName).edb"
+            LogFolderPath                 = "C:\Program Files\Microsoft\Exchange Server\V15\Mailbox\$($TestDBName)"
+            AllowFileRestore              = $true
+            AllowServiceRestart           = $true
+            AutoDagExcludeFromMonitoring  = $true
             BackgroundDatabaseMaintenance = $true
-            CalendarLoggingQuota = 'unlimited'
-            CircularLoggingEnabled = $true
-            DatabaseCopyCount = 1
+            CalendarLoggingQuota          = 'unlimited'
+            CircularLoggingEnabled        = $true
+            DatabaseCopyCount             = 1
             DataMoveReplicationConstraint = 'None'
-            DeletedItemRetention = '14.00:00:00'
-            EventHistoryRetentionPeriod = '03:04:05'
-            IsExcludedFromProvisioning = $false
-            IsSuspendedFromProvisioning = $false
-            JournalRecipient = $testMailbox.PrimarySmtpAddress.Address
-            MailboxRetention = '30.00:00:00'
-            MountAtStartup = $true
-            OfflineAddressBook = $testOabName
+            DeletedItemRetention          = '14.00:00:00'
+            EventHistoryRetentionPeriod   = '03:04:05'
+            IsExcludedFromProvisioning    = $false
+            IsSuspendedFromProvisioning   = $false
+            JournalRecipient              = $testMailbox.PrimarySmtpAddress.Address
+            MailboxRetention              = '30.00:00:00'
+            MountAtStartup                = $true
+            OfflineAddressBook            = $testOabName
             RetainDeletedItemsUntilBackup = $false
-            IssueWarningQuota = '27 MB'
-            ProhibitSendQuota = '1GB'
-            ProhibitSendReceiveQuota = '1.5 GB'
-            RecoverableItemsQuota = 'uNlImItEd'
-            RecoverableItemsWarningQuota = '1,000,448'
+            IssueWarningQuota             = '27 MB'
+            ProhibitSendQuota             = '1GB'
+            ProhibitSendReceiveQuota      = '1.5 GB'
+            RecoverableItemsQuota         = 'uNlImItEd'
+            RecoverableItemsWarningQuota  = '1,000,448'
         }
 
         $expectedGetResults = @{
-            Name = $TestDBName
-            Server = $env:COMPUTERNAME
-            EdbFilePath = "C:\Program Files\Microsoft\Exchange Server\V15\Mailbox\$($TestDBName)\$($TestDBName).edb"
-            LogFolderPath = "C:\Program Files\Microsoft\Exchange Server\V15\Mailbox\$($TestDBName)"
-            AllowFileRestore = $true
-            AutoDagExcludeFromMonitoring = $true
+            Name                          = $TestDBName
+            Server                        = $env:COMPUTERNAME
+            EdbFilePath                   = "C:\Program Files\Microsoft\Exchange Server\V15\Mailbox\$($TestDBName)\$($TestDBName).edb"
+            LogFolderPath                 = "C:\Program Files\Microsoft\Exchange Server\V15\Mailbox\$($TestDBName)"
+            AllowFileRestore              = $true
+            AutoDagExcludeFromMonitoring  = $true
             BackgroundDatabaseMaintenance = $true
-            CalendarLoggingQuota = 'unlimited'
-            CircularLoggingEnabled = $true
-            DatabaseCopyCount = 1
+            CalendarLoggingQuota          = 'unlimited'
+            CircularLoggingEnabled        = $true
+            DatabaseCopyCount             = 1
             DataMoveReplicationConstraint = 'None'
-            DeletedItemRetention = '14.00:00:00'
-            EventHistoryRetentionPeriod = '03:04:05'
-            IsExcludedFromProvisioning = $false
-            IsSuspendedFromProvisioning = $false
-            JournalRecipient = $testMailboxADObjectIDString
-            MailboxRetention = '30.00:00:00'
-            MountAtStartup = $true
-            OfflineAddressBook = "\$testOabName"
+            DeletedItemRetention          = '14.00:00:00'
+            EventHistoryRetentionPeriod   = '03:04:05'
+            IsExcludedFromProvisioning    = $false
+            IsSuspendedFromProvisioning   = $false
+            JournalRecipient              = $testMailboxADObjectIDString
+            MailboxRetention              = '30.00:00:00'
+            MountAtStartup                = $true
+            OfflineAddressBook            = "\$testOabName"
             RetainDeletedItemsUntilBackup = $false
-            IssueWarningQuota = '27 MB (28,311,552 bytes)'
-            ProhibitSendQuota = '1 GB (1,073,741,824 bytes)'
-            ProhibitSendReceiveQuota = '1.5 GB (1,610,612,736 bytes)'
-            RecoverableItemsQuota = 'uNlImItEd'
-            RecoverableItemsWarningQuota = '977 KB (1,000,448 bytes)'
+            IssueWarningQuota             = '27 MB (28,311,552 bytes)'
+            ProhibitSendQuota             = '1 GB (1,073,741,824 bytes)'
+            ProhibitSendReceiveQuota      = '1.5 GB (1,610,612,736 bytes)'
+            RecoverableItemsQuota         = 'uNlImItEd'
+            RecoverableItemsWarningQuota  = '977 KB (1,000,448 bytes)'
         }
 
         Test-TargetResourceFunctionality -Params $testParams `
-                                         -ContextLabel 'Create Test Database' `
-                                         -ExpectedGetResults $expectedGetResults
+            -ContextLabel 'Create Test Database' `
+            -ExpectedGetResults $expectedGetResults
 
         # Try changing Journal Recipient address to secondary address
         $testParams.JournalRecipient = $testMailboxSecondaryAddress
 
         Test-TargetResourceFunctionality -Params $testParams `
-                                         -ContextLabel 'Use secondary journaling address test' `
-                                         -ExpectedGetResults $expectedGetResults
+            -ContextLabel 'Use secondary journaling address test' `
+            -ExpectedGetResults $expectedGetResults
 
         # Now change properties on the test database
         $testParams.AllowFileRestore = $false
@@ -304,8 +304,8 @@ if ($exchangeInstalled)
         $expectedGetResults.RecoverableItemsWarningQuota = 'unlimited'
 
         Test-TargetResourceFunctionality -Params $testParams `
-                                         -ContextLabel 'Set remaining quotas to Unlimited' `
-                                         -ExpectedGetResults $expectedGetResults
+            -ContextLabel 'Set remaining quotas to Unlimited' `
+            -ExpectedGetResults $expectedGetResults
     }
 
     # Clean up the test database

--- a/tests/Integration/MSFT_xExchOwaVirtualDirectory.Integration.Tests.ps1
+++ b/tests/Integration/MSFT_xExchOwaVirtualDirectory.Integration.Tests.ps1
@@ -47,113 +47,113 @@ if ($exchangeInstalled)
     }
 
     # Remove our remote Exchange session so as not to interfere with actual Integration testing
-    Remove-RemoteExchangeSession
+    Remove-RemoteExchangeModule
 
     Describe 'Test Setting Properties with xExchOwaVirtualDirectory' {
         $testParams = @{
-            Identity =  "$($env:COMPUTERNAME)\owa (Default Web Site)"
-            Credential = $shellCredentials
+            Identity                               = "$($env:COMPUTERNAME)\owa (Default Web Site)"
+            Credential                             = $shellCredentials
             # AdfsAuthentication = $false #Don't test AdfsAuthentication changes in dedicated OWA tests, as they have to be done to ECP at the same time
-            ActionForUnknownFileAndMIMETypes = 'ForceSave'
-            BasicAuthentication = $true
-            ChangePasswordEnabled = $true
-            DigestAuthentication = $false
-            ExternalUrl = "https://$($serverFqdn)/owa"
-            FormsAuthentication = $true
-            GzipLevel = 'Off'
-            InstantMessagingEnabled = $false
-            InstantMessagingCertificateThumbprint = ''
-            InstantMessagingServerName = ''
-            InstantMessagingType = 'None'
-            InternalUrl = "https://$($serverFqdn)/owa"
+            ActionForUnknownFileAndMIMETypes       = 'ForceSave'
+            BasicAuthentication                    = $true
+            ChangePasswordEnabled                  = $true
+            DigestAuthentication                   = $false
+            ExternalUrl                            = "https://$($serverFqdn)/owa"
+            FormsAuthentication                    = $true
+            GzipLevel                              = 'Off'
+            InstantMessagingEnabled                = $false
+            InstantMessagingCertificateThumbprint  = ''
+            InstantMessagingServerName             = ''
+            InstantMessagingType                   = 'None'
+            InternalUrl                            = "https://$($serverFqdn)/owa"
             LogonPagePublicPrivateSelectionEnabled = $true
-            LogonPageLightSelectionEnabled = $true
-            UNCAccessOnPublicComputersEnabled = $true
-            UNCAccessOnPrivateComputersEnabled = $true
-            WindowsAuthentication = $false
-            WSSAccessOnPublicComputersEnabled = $true
-            WSSAccessOnPrivateComputersEnabled = $true
-            LogonFormat = 'PrincipalName'
-            DefaultDomain = 'contoso.local'
+            LogonPageLightSelectionEnabled         = $true
+            UNCAccessOnPublicComputersEnabled      = $true
+            UNCAccessOnPrivateComputersEnabled     = $true
+            WindowsAuthentication                  = $false
+            WSSAccessOnPublicComputersEnabled      = $true
+            WSSAccessOnPrivateComputersEnabled     = $true
+            LogonFormat                            = 'PrincipalName'
+            DefaultDomain                          = 'contoso.local'
         }
 
         $expectedGetResults = @{
-            Identity =  "$($env:COMPUTERNAME)\owa (Default Web Site)"
-            BasicAuthentication = $true
-            ActionForUnknownFileAndMIMETypes = 'ForceSave'
-            ChangePasswordEnabled = $true
-            DigestAuthentication = $false
-            ExternalUrl = "https://$($serverFqdn)/owa"
-            FormsAuthentication = $true
-            GzipLevel = 'Off'
-            InstantMessagingEnabled = $false
-            InstantMessagingCertificateThumbprint = ''
-            InstantMessagingServerName = ''
-            InstantMessagingType = 'None'
-            InternalUrl = "https://$($serverFqdn)/owa"
+            Identity                               = "$($env:COMPUTERNAME)\owa (Default Web Site)"
+            BasicAuthentication                    = $true
+            ActionForUnknownFileAndMIMETypes       = 'ForceSave'
+            ChangePasswordEnabled                  = $true
+            DigestAuthentication                   = $false
+            ExternalUrl                            = "https://$($serverFqdn)/owa"
+            FormsAuthentication                    = $true
+            GzipLevel                              = 'Off'
+            InstantMessagingEnabled                = $false
+            InstantMessagingCertificateThumbprint  = ''
+            InstantMessagingServerName             = ''
+            InstantMessagingType                   = 'None'
+            InternalUrl                            = "https://$($serverFqdn)/owa"
             LogonPagePublicPrivateSelectionEnabled = $true
-            LogonPageLightSelectionEnabled = $true
-            UNCAccessOnPublicComputersEnabled = $true
-            UNCAccessOnPrivateComputersEnabled = $true
-            WindowsAuthentication = $false
-            WSSAccessOnPublicComputersEnabled = $true
-            WSSAccessOnPrivateComputersEnabled = $true
-            LogonFormat = 'PrincipalName'
-            DefaultDomain = 'contoso.local'
+            LogonPageLightSelectionEnabled         = $true
+            UNCAccessOnPublicComputersEnabled      = $true
+            UNCAccessOnPrivateComputersEnabled     = $true
+            WindowsAuthentication                  = $false
+            WSSAccessOnPublicComputersEnabled      = $true
+            WSSAccessOnPrivateComputersEnabled     = $true
+            LogonFormat                            = 'PrincipalName'
+            DefaultDomain                          = 'contoso.local'
         }
 
         Test-TargetResourceFunctionality -Params $testParams -ContextLabel 'Set standard parameters' -ExpectedGetResults $expectedGetResults
 
 
         $testParams = @{
-            Identity =  "$($env:COMPUTERNAME)\owa (Default Web Site)"
-            Credential = $shellCredentials
-            ActionForUnknownFileAndMIMETypes = 'Block'
-            BasicAuthentication = $false
-            ChangePasswordEnabled = $false
-            DigestAuthentication = $true
-            ExternalUrl = ''
-            FormsAuthentication = $false
-            GzipLevel = 'High'
-            InstantMessagingEnabled = $true
-            InstantMessagingCertificateThumbprint = $imCertThumbprint
-            InstantMessagingServerName = $env:COMPUTERNAME
-            InstantMessagingType = 'Ocs'
-            InternalUrl = ''
+            Identity                               = "$($env:COMPUTERNAME)\owa (Default Web Site)"
+            Credential                             = $shellCredentials
+            ActionForUnknownFileAndMIMETypes       = 'Block'
+            BasicAuthentication                    = $false
+            ChangePasswordEnabled                  = $false
+            DigestAuthentication                   = $true
+            ExternalUrl                            = ''
+            FormsAuthentication                    = $false
+            GzipLevel                              = 'High'
+            InstantMessagingEnabled                = $true
+            InstantMessagingCertificateThumbprint  = $imCertThumbprint
+            InstantMessagingServerName             = $env:COMPUTERNAME
+            InstantMessagingType                   = 'Ocs'
+            InternalUrl                            = ''
             LogonPagePublicPrivateSelectionEnabled = $false
-            LogonPageLightSelectionEnabled = $false
-            UNCAccessOnPublicComputersEnabled = $false
-            UNCAccessOnPrivateComputersEnabled = $false
-            WindowsAuthentication = $true
-            WSSAccessOnPublicComputersEnabled = $false
-            WSSAccessOnPrivateComputersEnabled = $false
-            LogonFormat = 'FullDomain'
-            DefaultDomain = ''
+            LogonPageLightSelectionEnabled         = $false
+            UNCAccessOnPublicComputersEnabled      = $false
+            UNCAccessOnPrivateComputersEnabled     = $false
+            WindowsAuthentication                  = $true
+            WSSAccessOnPublicComputersEnabled      = $false
+            WSSAccessOnPrivateComputersEnabled     = $false
+            LogonFormat                            = 'FullDomain'
+            DefaultDomain                          = ''
         }
 
         $expectedGetResults = @{
-            Identity =  "$($env:COMPUTERNAME)\owa (Default Web Site)"
-            ActionForUnknownFileAndMIMETypes = 'Block'
-            BasicAuthentication = $false
-            ChangePasswordEnabled = $false
-            DigestAuthentication = $true
-            ExternalUrl = ''
-            FormsAuthentication = $false
-            GzipLevel = 'High'
-            InstantMessagingEnabled = $true
-            InstantMessagingCertificateThumbprint = $imCertThumbprint
-            InstantMessagingServerName = $env:COMPUTERNAME
-            InstantMessagingType = 'Ocs'
-            InternalUrl = ''
+            Identity                               = "$($env:COMPUTERNAME)\owa (Default Web Site)"
+            ActionForUnknownFileAndMIMETypes       = 'Block'
+            BasicAuthentication                    = $false
+            ChangePasswordEnabled                  = $false
+            DigestAuthentication                   = $true
+            ExternalUrl                            = ''
+            FormsAuthentication                    = $false
+            GzipLevel                              = 'High'
+            InstantMessagingEnabled                = $true
+            InstantMessagingCertificateThumbprint  = $imCertThumbprint
+            InstantMessagingServerName             = $env:COMPUTERNAME
+            InstantMessagingType                   = 'Ocs'
+            InternalUrl                            = ''
             LogonPagePublicPrivateSelectionEnabled = $false
-            LogonPageLightSelectionEnabled = $false
-            UNCAccessOnPublicComputersEnabled = $false
-            UNCAccessOnPrivateComputersEnabled = $false
-            WindowsAuthentication = $true
-            WSSAccessOnPublicComputersEnabled = $false
-            WSSAccessOnPrivateComputersEnabled = $false
-            LogonFormat = 'FullDomain'
-            DefaultDomain = ''
+            LogonPageLightSelectionEnabled         = $false
+            UNCAccessOnPublicComputersEnabled      = $false
+            UNCAccessOnPrivateComputersEnabled     = $false
+            WindowsAuthentication                  = $true
+            WSSAccessOnPublicComputersEnabled      = $false
+            WSSAccessOnPrivateComputersEnabled     = $false
+            LogonFormat                            = 'FullDomain'
+            DefaultDomain                          = ''
         }
 
         Test-TargetResourceFunctionality -Params $testParams -ContextLabel 'Try with the opposite of each property value' -ExpectedGetResults $expectedGetResults
@@ -161,19 +161,19 @@ if ($exchangeInstalled)
 
         # Set Authentication values back to default
         $testParams = @{
-            Identity =  "$($env:COMPUTERNAME)\owa (Default Web Site)"
-            Credential = $shellCredentials
-            BasicAuthentication = $true
-            DigestAuthentication = $false
-            FormsAuthentication = $true
+            Identity              = "$($env:COMPUTERNAME)\owa (Default Web Site)"
+            Credential            = $shellCredentials
+            BasicAuthentication   = $true
+            DigestAuthentication  = $false
+            FormsAuthentication   = $true
             WindowsAuthentication = $false
         }
 
         $expectedGetResults = @{
-            Identity =  "$($env:COMPUTERNAME)\owa (Default Web Site)"
-            BasicAuthentication = $true
-            DigestAuthentication = $false
-            FormsAuthentication = $true
+            Identity              = "$($env:COMPUTERNAME)\owa (Default Web Site)"
+            BasicAuthentication   = $true
+            DigestAuthentication  = $false
+            FormsAuthentication   = $true
             WindowsAuthentication = $false
         }
 

--- a/tests/Integration/MSFT_xExchUMService.Integration.Tests.ps1
+++ b/tests/Integration/MSFT_xExchUMService.Integration.Tests.ps1
@@ -47,18 +47,18 @@ if ($exchangeInstalled)
         }
 
         # Remove our remote Exchange session so as not to interfere with actual Integration testing
-        Remove-RemoteExchangeSession
+        Remove-RemoteExchangeModule
 
         Describe 'Test Setting Properties with xExchUMService' {
             $testParams = @{
-                Identity =  $env:COMPUTERNAME
-                Credential = $shellCredentials
+                Identity      = $env:COMPUTERNAME
+                Credential    = $shellCredentials
                 UMStartupMode = 'TLS'
-                DialPlans = @()
+                DialPlans     = @()
             }
 
             $expectedGetResults = @{
-                Identity =  $env:COMPUTERNAME
+                Identity      = $env:COMPUTERNAME
                 UMStartupMode = 'TLS'
             }
 

--- a/tests/Integration/xExchangeCommon.Integration.Tests.ps1
+++ b/tests/Integration/xExchangeCommon.Integration.Tests.ps1
@@ -20,7 +20,7 @@ function Remove-ExistingPSSession
     param ()
 
     Context 'Remove existing Remote PowerShell Session to Exchange' {
-        Remove-RemoteExchangeSession
+        Remove-RemoteExchangeModule
 
         $Session = $null
         $Session = Get-ExistingRemoteExchangeSession

--- a/tests/Unit/xExchangeHelper.tests.ps1
+++ b/tests/Unit/xExchangeHelper.tests.ps1
@@ -5,7 +5,14 @@ param()
 $script:projectPath = "$PSScriptRoot\..\.." | Convert-Path
 $script:projectName = (Get-ChildItem -Path "$script:projectPath\*\*.psd1" | Where-Object -FilterScript {
         ($_.Directory.Name -match 'source|src' -or $_.Directory.Name -eq $_.BaseName) -and
-        $(try { Test-ModuleManifest -Path $_.FullName -ErrorAction Stop } catch { $false })
+        $(try
+            {
+                Test-ModuleManifest -Path $_.FullName -ErrorAction Stop
+            }
+            catch
+            {
+                $false
+            })
     }).BaseName
 
 $script:parentModule = Get-Module -Name $script:projectName -ListAvailable | Select-Object -First 1
@@ -38,7 +45,7 @@ try
         Describe 'xExchangeHelper\Get-ExchangeInstallStatus' -Tag 'Helper' {
             # Used for calls to Get-InstallStatus
             $getInstallStatusParams = @{
-                Path = 'C:\Exchange\setup.exe'
+                Path      = 'C:\Exchange\setup.exe'
                 Arguments = '/mode:Install /role:Mailbox /Iacceptexchangeserverlicenseterms'
             }
 
@@ -154,7 +161,7 @@ try
                     Mock -CommandName Test-ShouldUpgradeExchange -MockWith { return $true }
 
                     $getInstallStatusParams = @{
-                        Path = 'C:\Exchange\setup.exe'
+                        Path      = 'C:\Exchange\setup.exe'
                         Arguments = '/mode:Upgrade /Iacceptexchangeserverlicenseterms'
                     }
 
@@ -200,7 +207,7 @@ try
                     $error2 = Get-PreviousError
 
                     # Run a command that should always succeed
-                    Get-ChildItem  | Out-Null
+                    Get-ChildItem | Out-Null
 
                     # Get the previous error one more time
                     $error3 = Get-PreviousError
@@ -239,13 +246,13 @@ try
 
         Describe 'xExchangeHelper\Assert-IsSupportedWithExchangeVersion' -Tag 'Helper' {
             $supportedVersionTestCases = @(
-                @{Name='2013 Operation Supported on 2013';      ExchangeVersion='2013'; SupportedVersions='2013'}
-                @{Name='2013 Operation Supported on 2013,2019'; ExchangeVersion='2013'; SupportedVersions='2013', '2019'}
+                @{Name = '2013 Operation Supported on 2013'; ExchangeVersion = '2013'; SupportedVersions = '2013' }
+                @{Name = '2013 Operation Supported on 2013,2019'; ExchangeVersion = '2013'; SupportedVersions = '2013', '2019' }
             )
 
             $notSupportedVersionTestCases = @(
-                @{Name='2013 Operation Not Supported on 2016';      ExchangeVersion='2013'; SupportedVersions='2016'}
-                @{Name='2013 Operation Not Supported on 2016,2019'; ExchangeVersion='2013'; SupportedVersions='2016', '2019'}
+                @{Name = '2013 Operation Not Supported on 2016'; ExchangeVersion = '2013'; SupportedVersions = '2016' }
+                @{Name = '2013 Operation Not Supported on 2016,2019'; ExchangeVersion = '2013'; SupportedVersions = '2016', '2019' }
             )
 
             Context 'When a supported version is passed' {
@@ -274,14 +281,16 @@ try
                 Define an empty function for Get-Recipient, so Pester has something to Mock.
                 This cmdlet is normally loaded as part of GetRemoteExchangeSession.
             #>
-            function Get-Recipient {}
+            function Get-Recipient
+            {
+            }
 
             AfterEach {
                 Assert-VerifiableMock
             }
 
             # Setup test objects for calls to Compare-ADObjectIdToSmtpAddressString
-            $testADObjectID = New-Object -TypeName PSObject -Property @{DistinguishedName='CN=TestUser,DC=contoso,DC=local'}
+            $testADObjectID = New-Object -TypeName PSObject -Property @{DistinguishedName = 'CN=TestUser,DC=contoso,DC=local' }
             $testAddress = 'testuser@contoso.local'
             $testBadAddress = 'baduser@contoso.local'
 
@@ -403,7 +412,7 @@ try
 
                     $processes = Invoke-DotSourcedScript -ScriptPath 'Get-Process' -ScriptParams $scriptParams
 
-                    ($processes | Where-Object -FilterScript {$_.ProcessName -like $testProcess}).Count | Should -BeGreaterThan 0
+                    ($processes | Where-Object -FilterScript { $_.ProcessName -like $testProcess }).Count | Should -BeGreaterThan 0
                 }
             }
 
@@ -424,7 +433,7 @@ try
                         }
                     }
 
-                    $returnValues = Invoke-DotSourcedScript -ScriptPath 'Start-Sleep' -ScriptParams @{Seconds=0} -CommandsToExecuteInScope $commandToExecuteAfterDotSourcing -ParamsForCommandsToExecuteInScope $commandParamsToExecuteAfterDotSourcing
+                    $returnValues = Invoke-DotSourcedScript -ScriptPath 'Start-Sleep' -ScriptParams @{Seconds = 0 } -CommandsToExecuteInScope $commandToExecuteAfterDotSourcing -ParamsForCommandsToExecuteInScope $commandParamsToExecuteAfterDotSourcing
 
                     $returnValues.Count -gt 0 -and $returnValues.ContainsKey('Get-Process') -and $null -ne $returnValues['Get-Process'] | Should -Be $true
                 }
@@ -463,9 +472,9 @@ try
             }
 
             $validExchangeYears = @(
-                @{Year='2013'}
-                @{Year='2016'}
-                @{Year='2019'}
+                @{Year = '2013' }
+                @{Year = '2016' }
+                @{Year = '2019' }
             )
 
             Context 'When Test-ExchangePresent is called with a valid Exchange Version' {
@@ -483,10 +492,10 @@ try
             }
 
             $inValidExchangeYears = @(
-                @{Year='2012'}
-                @{Year=''}
-                @{Year='N/A'}
-                @{Year=$null}
+                @{Year = '2012' }
+                @{Year = '' }
+                @{Year = 'N/A' }
+                @{Year = $null }
             )
 
             Context 'When Test-ExchangePresent is called with an invalid Exchange Version' {
@@ -604,9 +613,9 @@ try
                     Watermark         = 1
                 }
                 @{
-                    UnpackedVersion   = 1
-                    Action            = 1
-                    Watermark         = 1
+                    UnpackedVersion = 1
+                    Action          = 1
+                    Watermark       = 1
                 }
             )
 
@@ -644,7 +653,9 @@ try
 
         Describe 'xExchangeHelper\Set-WSManConfigStatus' -Tag 'Helper' {
             # Define an empty winrm function so we can Mock calls to the winrm executable
-            function winrm {}
+            function winrm
+            {
+            }
 
             AfterEach {
                 Assert-VerifiableMock
@@ -652,7 +663,7 @@ try
 
             Context 'When Set-WSManConfigStatus is called and the UpdatedConfig key does not exist' {
                 It 'Should attempt to configure WinRM' {
-                    Mock -CommandName Get-ItemProperty -Verifiable -MockWith { return @{SomeOtherProp = 'SomeOtherValue'} }
+                    Mock -CommandName Get-ItemProperty -Verifiable -MockWith { return @{SomeOtherProp = 'SomeOtherValue' } }
                     Mock -CommandName Set-Location -Verifiable
                     Mock -CommandName winrm -Verifiable
 
@@ -662,7 +673,7 @@ try
 
             Context 'When Set-WSManConfigStatus is called and the UpdatedConfig key exists' {
                 It 'Should execute without attempting to configure WinRM' {
-                    Mock -CommandName Get-ItemProperty -Verifiable -MockWith { return @{UpdatedConfig = 'SomeValue'} }
+                    Mock -CommandName Get-ItemProperty -Verifiable -MockWith { return @{UpdatedConfig = 'SomeValue' } }
                     Mock -CommandName winrm
 
                     Set-WSManConfigStatus
@@ -689,7 +700,7 @@ try
 
             Context 'When Test-UMLanguagePackInstalled is called and the specified Culture key exists' {
                 It 'Should return true' {
-                    Mock -CommandName Get-ItemProperty -Verifiable -MockWith { return @{TestCulture = $testCultureName} }
+                    Mock -CommandName Get-ItemProperty -Verifiable -MockWith { return @{TestCulture = $testCultureName } }
 
                     Test-UMLanguagePackInstalled -Culture $testCultureName | Should -Be $true
                 }
@@ -697,7 +708,7 @@ try
 
             Context 'When Test-UMLanguagePackInstalled is called and the specified Culture key does not exist' {
                 It 'Should return false' {
-                    Mock -CommandName Get-ItemProperty -Verifiable -MockWith { return @{SomeOtherCulture = 'SomeOtherCulture'} }
+                    Mock -CommandName Get-ItemProperty -Verifiable -MockWith { return @{SomeOtherCulture = 'SomeOtherCulture' } }
 
                     Test-UMLanguagePackInstalled -Culture $testCultureName | Should -Be $false
                 }
@@ -705,9 +716,9 @@ try
         }
 
         Describe 'xExchangeHelper\Test-ShouldInstallUMLanguagePack' -Tag 'Helper' {
-            $noLanguagePackArgs     = '/IAcceptExchangeServerLicenseTerms /mode:Install /r:MB'
+            $noLanguagePackArgs = '/IAcceptExchangeServerLicenseTerms /mode:Install /r:MB'
             $singleLanguagePackArgs = '/AddUmLanguagePack:ja-JP /s:d:\Exchange\UMLanguagePacks /IAcceptExchangeServerLicenseTerms'
-            $multiLanguagePackArgs  = '/AddUmLanguagePack:es-MX,de-DE /s:d:\Exchange\UMLanguagePacks /IAcceptExchangeServerLicenseTerms'
+            $multiLanguagePackArgs = '/AddUmLanguagePack:es-MX,de-DE /s:d:\Exchange\UMLanguagePacks /IAcceptExchangeServerLicenseTerms'
 
             AfterEach {
                 Assert-VerifiableMock
@@ -981,7 +992,7 @@ try
 
             Context 'When Get-ExchangeUninstallKey is called and Exchange 2016 or 2019 is installed' {
                 It 'Should return the 2016/2019 uninstall key' {
-                    Mock -CommandName Get-Item -Verifiable -ParameterFilter {$Path -like 'HKLM:\SOFTWARE\Microsoft\Windows\CurrentVersion\Uninstall\{CD981244-E9B8-405A-9026-6AEB9DCEF1F1}'} -MockWith { return $true }
+                    Mock -CommandName Get-Item -Verifiable -ParameterFilter { $Path -like 'HKLM:\SOFTWARE\Microsoft\Windows\CurrentVersion\Uninstall\{CD981244-E9B8-405A-9026-6AEB9DCEF1F1}' } -MockWith { return $true }
 
                     Get-ExchangeUninstallKey | Should -Be -Not $Null
                 }
@@ -989,8 +1000,8 @@ try
 
             Context 'When Get-ExchangeUninstallKey is called and Exchange 2013 is installed' {
                 It 'Should return the 2016/2019 uninstall key' {
-                    Mock -CommandName Get-Item -Verifiable -ParameterFilter {$Path -like 'HKLM:\SOFTWARE\Microsoft\Windows\CurrentVersion\Uninstall\{CD981244-E9B8-405A-9026-6AEB9DCEF1F1}'} -MockWith { return $null }
-                    Mock -CommandName Get-Item -Verifiable -ParameterFilter {$Path -like 'HKLM:\SOFTWARE\Microsoft\Windows\CurrentVersion\Uninstall\{4934D1EA-BE46-48B1-8847-F1AF20E892C1}'} -MockWith { return $true }
+                    Mock -CommandName Get-Item -Verifiable -ParameterFilter { $Path -like 'HKLM:\SOFTWARE\Microsoft\Windows\CurrentVersion\Uninstall\{CD981244-E9B8-405A-9026-6AEB9DCEF1F1}' } -MockWith { return $null }
+                    Mock -CommandName Get-Item -Verifiable -ParameterFilter { $Path -like 'HKLM:\SOFTWARE\Microsoft\Windows\CurrentVersion\Uninstall\{4934D1EA-BE46-48B1-8847-F1AF20E892C1}' } -MockWith { return $true }
 
                     Get-ExchangeUninstallKey | Should -Be -Not $Null
                 }
@@ -998,8 +1009,8 @@ try
 
             Context 'When Get-ExchangeUninstallKey is called and no Exchange is installed' {
                 It 'Should return NULL' {
-                    Mock -CommandName Get-Item -Verifiable -ParameterFilter {$Path -like 'HKLM:\SOFTWARE\Microsoft\Windows\CurrentVersion\Uninstall\{CD981244-E9B8-405A-9026-6AEB9DCEF1F1}'} -MockWith { return $null }
-                    Mock -CommandName Get-Item -Verifiable -ParameterFilter {$Path -like 'HKLM:\SOFTWARE\Microsoft\Windows\CurrentVersion\Uninstall\{4934D1EA-BE46-48B1-8847-F1AF20E892C1}'} -MockWith { return $null }
+                    Mock -CommandName Get-Item -Verifiable -ParameterFilter { $Path -like 'HKLM:\SOFTWARE\Microsoft\Windows\CurrentVersion\Uninstall\{CD981244-E9B8-405A-9026-6AEB9DCEF1F1}' } -MockWith { return $null }
+                    Mock -CommandName Get-Item -Verifiable -ParameterFilter { $Path -like 'HKLM:\SOFTWARE\Microsoft\Windows\CurrentVersion\Uninstall\{4934D1EA-BE46-48B1-8847-F1AF20E892C1}' } -MockWith { return $null }
 
                     Get-ExchangeUninstallKey | Should -Be $Null
                 }
@@ -1013,12 +1024,12 @@ try
 
             Context 'When DetailedInstalledVersion is called and a valid key is returned by Get-ExchangeUninstallKey' {
                 It 'Should return custom object with VersionMajor and VersionMinor properties' {
-                    Mock -CommandName Get-ExchangeUninstallKey -Verifiable -MockWith { return @{Name = 'SomeKeyName'} }
-                    Mock -CommandName Get-ItemProperty -Verifiable -ParameterFilter {$Name -eq 'DisplayVersion'} -MockWith {
-                        return [PSCustomObject] @{DisplayVersion = '15.1.1531.13'} }
-                    Mock -CommandName Get-ItemProperty -Verifiable -ParameterFilter {$Name -eq 'VersionMajor'} -MockWith {
-                        return [PSCustomObject] @{VersionMajor = 15} }
-                    Mock -CommandName Get-ItemProperty -Verifiable -ParameterFilter {$Name -eq 'VersionMinor'} -MockWith {
+                    Mock -CommandName Get-ExchangeUninstallKey -Verifiable -MockWith { return @{Name = 'SomeKeyName' } }
+                    Mock -CommandName Get-ItemProperty -Verifiable -ParameterFilter { $Name -eq 'DisplayVersion' } -MockWith {
+                        return [PSCustomObject] @{DisplayVersion = '15.1.1531.13' } }
+                    Mock -CommandName Get-ItemProperty -Verifiable -ParameterFilter { $Name -eq 'VersionMajor' } -MockWith {
+                        return [PSCustomObject] @{VersionMajor = 15 } }
+                    Mock -CommandName Get-ItemProperty -Verifiable -ParameterFilter { $Name -eq 'VersionMinor' } -MockWith {
                         return [PSCustomObject] @{ VersionMinor = 1 }
                     }
 
@@ -1046,62 +1057,62 @@ try
             }
 
             $cases = @(
-                        @{
-                            Case = 'Setup.exe is newer. Commandline Argment is /mode:Upgrade'
-                            SetupVersionMajor = 15
-                            SetupVersionMinor = 1
-                            SetupVersionBuild = 2000
-                            ExchangeVersionMajor = 15
-                            ExchangeVersionMinor = 1
-                            ExchangeVersionBuild = 1800
-                            Result = $true
-                            Arguments = '/mode:Upgrade /Iacceptexchangeserverlicenseterms'
-                        }
-                        @{
-                            Case = 'Setup.exe is newer. Commandline Argment is /m:Upgrade'
-                            SetupVersionMajor = 15
-                            SetupVersionMinor = 1
-                            SetupVersionBuild = 2000
-                            ExchangeVersionMajor = 15
-                            ExchangeVersionMinor = 1
-                            ExchangeVersionBuild = 1800
-                            Result = $true
-                            Arguments = '/m:upgrade /Iacceptexchangeserverlicenseterms'
-                        }
-                        @{
-                            Case = 'Setup.exe and installed Exchange version is the same.'
-                            SetupVersionMajor = 15
-                            SetupVersionMinor = 1
-                            SetupVersionBuild = 2000
-                            ExchangeVersionMajor = 15
-                            ExchangeVersionMinor = 1
-                            ExchangeVersionBuild = 2000
-                            Result = $false
-                            Arguments = '/mode:Upgrade /Iacceptexchangeserverlicenseterms'
-                        }
-                        @{
-                            Case = 'Installed Exchange version is different than the setup.exe. e.g. 2013, 2016'
-                            SetupVersionMajor = 15
-                            SetupVersionMinor = 1
-                            SetupVersionBuild = 2000
-                            ExchangeVersionMajor = 15
-                            ExchangeVersionMinor = 0
-                            ExchangeVersionBuild = 2000
-                            Result = $false
-                            Arguments = '/mode:Upgrade /Iacceptexchangeserverlicenseterms'
-                        }
-                        @{
-                            Case = 'Setup.exe version is different than the installed Exchange. e.g. 2013, 2016'
-                            SetupVersionMajor = 15
-                            SetupVersionMinor = 0
-                            SetupVersionBuild = 2000
-                            ExchangeVersionMajor = 15
-                            ExchangeVersionMinor = 1
-                            ExchangeVersionBuild = 2000
-                            Result = $false
-                            Arguments = '/mode:Upgrade /Iacceptexchangeserverlicenseterms'
-                        }
-                    )
+                @{
+                    Case                 = 'Setup.exe is newer. Commandline Argment is /mode:Upgrade'
+                    SetupVersionMajor    = 15
+                    SetupVersionMinor    = 1
+                    SetupVersionBuild    = 2000
+                    ExchangeVersionMajor = 15
+                    ExchangeVersionMinor = 1
+                    ExchangeVersionBuild = 1800
+                    Result               = $true
+                    Arguments            = '/mode:Upgrade /Iacceptexchangeserverlicenseterms'
+                }
+                @{
+                    Case                 = 'Setup.exe is newer. Commandline Argment is /m:Upgrade'
+                    SetupVersionMajor    = 15
+                    SetupVersionMinor    = 1
+                    SetupVersionBuild    = 2000
+                    ExchangeVersionMajor = 15
+                    ExchangeVersionMinor = 1
+                    ExchangeVersionBuild = 1800
+                    Result               = $true
+                    Arguments            = '/m:upgrade /Iacceptexchangeserverlicenseterms'
+                }
+                @{
+                    Case                 = 'Setup.exe and installed Exchange version is the same.'
+                    SetupVersionMajor    = 15
+                    SetupVersionMinor    = 1
+                    SetupVersionBuild    = 2000
+                    ExchangeVersionMajor = 15
+                    ExchangeVersionMinor = 1
+                    ExchangeVersionBuild = 2000
+                    Result               = $false
+                    Arguments            = '/mode:Upgrade /Iacceptexchangeserverlicenseterms'
+                }
+                @{
+                    Case                 = 'Installed Exchange version is different than the setup.exe. e.g. 2013, 2016'
+                    SetupVersionMajor    = 15
+                    SetupVersionMinor    = 1
+                    SetupVersionBuild    = 2000
+                    ExchangeVersionMajor = 15
+                    ExchangeVersionMinor = 0
+                    ExchangeVersionBuild = 2000
+                    Result               = $false
+                    Arguments            = '/mode:Upgrade /Iacceptexchangeserverlicenseterms'
+                }
+                @{
+                    Case                 = 'Setup.exe version is different than the installed Exchange. e.g. 2013, 2016'
+                    SetupVersionMajor    = 15
+                    SetupVersionMinor    = 0
+                    SetupVersionBuild    = 2000
+                    ExchangeVersionMajor = 15
+                    ExchangeVersionMinor = 1
+                    ExchangeVersionBuild = 2000
+                    Result               = $false
+                    Arguments            = '/mode:Upgrade /Iacceptexchangeserverlicenseterms'
+                }
+            )
 
             Context 'When Test-ShouldUpgradeExchange is called for different cases.' {
                 It 'For case <Case> should return <Result>' -TestCases $cases {
@@ -1163,7 +1174,7 @@ try
                         return $null
                     }
 
-                    Mock -CommandName Write-Error -Verifiable -MockWith {}
+                    Mock -CommandName Write-Error -Verifiable -MockWith { }
 
                     Test-ShouldUpgradeExchange -Path 'test' -Arguments $Arguments | Should -Be $false
                 }
@@ -1173,7 +1184,7 @@ try
                 It 'Should return with $false' {
                     $Arguments = '/mode:Upgrade /Iacceptexchangeserverlicenseterms'
 
-                    Mock -CommandName Write-Error -Verifiable -MockWith {}
+                    Mock -CommandName Write-Error -Verifiable -MockWith { }
 
                     Mock -CommandName Get-SetupExeVersion -Verifiable -MockWith {
                         return [PSCustomObject] @{
@@ -1195,7 +1206,7 @@ try
                 It 'Should return with $false' {
                     $Arguments = '/mode:Upgrade /Iacceptexchangeserverlicenseterms'
 
-                    Mock -CommandName Write-Error -Verifiable -MockWith {}
+                    Mock -CommandName Write-Error -Verifiable -MockWith { }
 
                     Mock -CommandName Get-SetupExeVersion -Verifiable -MockWith {
                         return $false
@@ -1249,45 +1260,6 @@ try
             }
         }
 
-        Describe 'xExchangeHelper\Get-ExistingRemoteExchangeSession' -Tag 'Helper' {
-            AfterEach {
-                Assert-VerifiableMock
-            }
-
-            Context 'When Get-ExistingRemoteExchangeSession is called and there is an existing Remote Exchange Session in an Opened state' {
-                It 'Should return the session' {
-                    Mock -CommandName Get-PSSession -Verifiable -MockWith {
-                        return @{
-                            State = 'Opened'
-                        }
-                    }
-
-                    Get-ExistingRemoteExchangeSession | Should -Be -Not $null
-                }
-            }
-
-            Context 'When Get-ExistingRemoteExchangeSession is called and there is an existing Remote Exchange Session in a state other than Opened' {
-                It 'Should return null' {
-                    Mock -CommandName Get-PSSession -Verifiable -MockWith {
-                        return @{
-                            State = 'Broken'
-                        }
-                    }
-                    Mock -CommandName Remove-RemoteExchangeSession -Verifiable
-
-                    Get-ExistingRemoteExchangeSession | Should -Be $null
-                }
-            }
-
-            Context 'When Get-ExistingRemoteExchangeSession is called and there is not an existing Remote Exchange Session' {
-                It 'Should return null' {
-                    Mock -CommandName Get-PSSession -Verifiable -MockWith { return $null }
-
-                    Get-ExistingRemoteExchangeSession | Should -Be $null
-                }
-            }
-        }
-
         Describe 'xExchangeHelper\Get-RemoteExchangeSession' -Tag 'Helper' {
             AfterEach {
                 Assert-VerifiableMock
@@ -1298,12 +1270,12 @@ try
                     Mock -CommandName Test-ExchangeSetupRunning -Verifiable -MockWith { return $true }
 
                     { Get-RemoteExchangeSession } | `
-                        Should -Throw -ExpectedMessage 'Exchange Setup is currently running. Preventing creation of new Remote PowerShell session to Exchange.'
+                            Should -Throw -ExpectedMessage 'Exchange Setup is currently running. Preventing creation of new Remote PowerShell session to Exchange.'
                 }
             }
 
-            Context 'When Get-RemoteExchangeSession is called, setup is not running, and an existing session exists' {
-                It 'Should return the existing session' {
+            Context 'When Get-RemoteExchangeSession is called, setup is not running, and no exported module exists' {
+                It 'Should export the module' {
                     Mock -CommandName Test-ExchangeSetupRunning -Verifiable -MockWith { return $false }
                     Mock -CommandName Get-ExistingRemoteExchangeSession -Verifiable -MockWith {
                         return @{
@@ -1311,43 +1283,60 @@ try
                         }
                     }
                     Mock -CommandName New-RemoteExchangeSession
-                    Mock -CommandName Import-RemoteExchangeSession
+                    Mock -CommandName Export-PSSession
+                    Mock -CommandName Import-Module
 
                     Get-RemoteExchangeSession
 
-                    Assert-MockCalled -CommandName New-RemoteExchangeSession -Times 0
+                    Assert-MockCalled -CommandName New-RemoteExchangeSession -Times 1
+                    Assert-MockCalled -CommandName Export-PSSession -Times 1
+                    Assert-MockCalled -CommandName Import-Module -Times 1
                 }
             }
 
-            Context 'When Get-RemoteExchangeSession is called, setup is not running, and no existing session exists' {
-                It 'Should create and return the existing session' {
+            Context 'When Get-RemoteExchangeSession is called, setup is not running, exported module exists and there is no existing session' {
+                It 'Should create a session and import the module' {
                     Mock -CommandName Test-ExchangeSetupRunning -Verifiable -MockWith { return $false }
                     Mock -CommandName Get-ExistingRemoteExchangeSession -Verifiable -MockWith { return $null }
+                    Mock -CommandName Test-Path -ParameterFilter { $Path -eq "$env:TEMP\DSCExchangeModule" } -Verifiable -MockWith { $true }
                     Mock -CommandName New-RemoteExchangeSession -Verifiable -MockWith {
                         return @{
                             State = 'Opened'
                         }
                     }
-                    Mock -CommandName Import-RemoteExchangeSession -Verifiable
+                    Mock -CommandName Import-Module -ParameterFilter { $ArgumentList.State -eq 'Opened' } -Verifiable
 
                     Get-RemoteExchangeSession
+
+                    Assert-MockCalled -CommandName New-RemoteExchangeSession -Times 1
+                    Assert-MockCalled -CommandName Import-Module -Times 1
                 }
             }
 
-            Context 'When Get-RemoteExchangeSession is called, setup is not running, no existing session exists, and creation of the session fails' {
-                It 'Should throw an exception' {
+            Context 'When Get-RemoteExchangeSession is called, setup is not running, exported module exists and there is a existing session' {
+                It 'Should create only import the module' {
                     Mock -CommandName Test-ExchangeSetupRunning -Verifiable -MockWith { return $false }
-                    Mock -CommandName Get-ExistingRemoteExchangeSession -Verifiable -MockWith { return $null }
-                    Mock -CommandName New-RemoteExchangeSession -Verifiable -MockWith { return $null }
+                    Mock -CommandName Get-ExistingRemoteExchangeSession -Verifiable -MockWith {
+                        return @{
+                            State = 'Opened'
+                        }
+                    }
+                    Mock -CommandName New-RemoteExchangeSession -Verifiable
+                    Mock -CommandName Import-Module -ParameterFilter { $ArgumentList.State -eq 'Opened' } -Verifiable
 
-                    { Get-RemoteExchangeSession } | Should -Throw -ExpectedMessage 'Failed to establish remote PowerShell session to local server.'
+                    Get-RemoteExchangeSession
+
+                    Assert-MockCalled -CommandName New-RemoteExchangeSession -Times 0
+                    Assert-MockCalled -CommandName Import-Module -Times 1
                 }
             }
         }
 
         Describe 'xExchangeHelper\New-RemoteExchangeSession' -Tag 'Helper' {
             # Define empty function _NewExchangeRunspace so Mock can override it
-            function _NewExchangeRunspace {}
+            function _NewExchangeRunspace
+            {
+            }
 
             AfterEach {
                 Assert-VerifiableMock
@@ -1358,7 +1347,7 @@ try
                     Mock -CommandName Test-ExchangeSetupComplete -Verifiable -MockWith { return $false }
 
                     { New-RemoteExchangeSession } | `
-                        Should -Throw -ExpectedMessage 'A supported version of Exchange is either not present, or not fully installed on this machine.'
+                            Should -Throw -ExpectedMessage 'A supported version of Exchange is either not present, or not fully installed on this machine.'
                 }
             }
 
@@ -1388,10 +1377,14 @@ try
             }
         }
 
-        Describe 'xExchangeHelper\Import-RemoteExchangeSession' -Tag 'Helper' {
+        Describe 'xExchangeHelper\Import-RemoteExchangeModule' -Tag 'Helper' {
             # Override functions which have non-Mockable parameter types
-            function Import-PSSession {}
-            function Import-Module {}
+            function Export-PSSession
+            {
+            }
+            function Import-Module
+            {
+            }
 
             AfterEach {
                 Assert-VerifiableMock
@@ -1400,45 +1393,52 @@ try
             $commandToLoad = 'Get-ExchangeServer'
             $commandsToLoad = @($commandToLoad)
 
-            Context 'When Import-RemoteExchangeSession is called and CommandsToLoad is passed' {
+            Context 'When Import-RemoteExchangeModule is called and CommandsToLoad is passed' {
                 It 'Should import the session and load the commands' {
                     Mock `
-                        -CommandName Import-PSSession `
+                        -CommandName Export-PSSession `
                         -Verifiable `
-                        -ParameterFilter {$CommandsToLoad.Count -eq 1 -and $CommandsToLoad[0] -like $commandToLoad} -MockWith { return $true }
-                    Mock -CommandName Import-Module -Verifiable
+                        -ParameterFilter { $OutputModule -eq "$env:TEMP\DSCExchangeModule" } -MockWith { return $true }
+                    Mock `
+                        -CommandName Import-Module `
+                        -ParameterFilter { $Function.Count -eq 1 -and $Function[0] -like $commandToLoad } `
+                        -Verifiable
 
-                    Import-RemoteExchangeSession -Session 'SomeSession' -CommandsToLoad $commandsToLoad
+                    Import-RemoteExchangeModule -Session 'SomeSession' -CommandsToLoad $commandsToLoad
                 }
             }
 
-            Context 'When Import-RemoteExchangeSession is called and CommandsToLoad is not passed' {
+            Context 'When Import-RemoteExchangeModule is called and CommandsToLoad is not passed' {
                 It 'Should import the session and load all commands' {
                     Mock `
-                        -CommandName Import-PSSession `
+                        -CommandName Export-PSSession `
                         -Verifiable `
-                        -ParameterFilter {$CommandsToLoad.Count -eq 1 -and $CommandsToLoad[0] -like '*'} -MockWith { return $true }
-                    Mock -CommandName Import-Module -Verifiable
+                        -ParameterFilter { $OutputModule -eq "$env:TEMP\DSCExchangeModule" } -MockWith { return $true }
+                    Mock `
+                        -CommandName Import-Module `
+                        -ParameterFilter { $Function.Count -eq 1 -and $Function[0] -eq '*' } `
+                        -Verifiable
 
-                    Import-RemoteExchangeSession -Session 'SomeSession'
+                    Import-RemoteExchangeModule -Session 'SomeSession'
                 }
             }
         }
 
-        Describe 'xExchangeHelper\Remove-RemoteExchangeSession' -Tag 'Helper' {
+        Describe 'xExchangeHelper\Remove-RemoteExchangeModule' -Tag 'Helper' {
             # Override functions which have non-Mockable parameter types
-            function Remove-PSSession {}
+            function Remove-PSSession
+            {
+            }
 
             AfterEach {
                 Assert-VerifiableMock
             }
 
-            Context 'When Remove-RemoteExchangeSession is called and sessions exist' {
-                It 'Should remove the sessions' {
-                    Mock -CommandName Get-ExistingRemoteExchangeSession -Verifiable -MockWith { return 'SomeSession' }
-                    Mock -CommandName Remove-PSSession -Verifiable
+            Context 'When Remove-RemoteExchangeModule is called' {
+                It 'Should remove the module' {
+                    Mock -CommandName Remove-Module -Verifiable
 
-                    Remove-RemoteExchangeSession
+                    Remove-RemoteExchangeModule
                 }
             }
         }
@@ -1629,7 +1629,9 @@ try
 
         Describe 'xExchangeHelper\Compare-UnlimitedToString' -Tag 'Helper' {
             # Override functions which have non-Mockable parameter types
-            function Compare-ByteQuantifiedSizeToString {}
+            function Compare-ByteQuantifiedSizeToString
+            {
+            }
 
             AfterEach {
                 Assert-VerifiableMock
@@ -1643,7 +1645,7 @@ try
                 It 'Should call Compare-StringToString, passing Unlimited as the first string, and the input string as the second' {
                     Mock `
                         -CommandName Compare-StringToString `
-                        -ParameterFilter {$String2 -eq 'unlimitedUnlimitedComp'} `
+                        -ParameterFilter { $String2 -eq 'unlimitedUnlimitedComp' } `
                         -Verifiable `
                         -MockWith { return $true }
 
@@ -1658,7 +1660,7 @@ try
 
             Context 'When Compare-UnlimitedToString is called, the Unlimited is not set to Unlimited, and the string equals Unlimited' {
                 It 'Should return false' {
-                    Mock -CommandName Compare-StringToString -ParameterFilter {$String2 -eq 'Unlimited'} -Verifiable -MockWith { return $true }
+                    Mock -CommandName Compare-StringToString -ParameterFilter { $String2 -eq 'Unlimited' } -Verifiable -MockWith { return $true }
 
                     Compare-UnlimitedToString -Unlimited $unlimitedInt32 -String 'Unlimited' | Should -Be $false
                 }
@@ -1668,7 +1670,7 @@ try
                 It 'Should call Compare-StringToString, passing the Unlimited value as the first string, and the input string as the second' {
                     Mock `
                         -CommandName Compare-StringToString `
-                        -ParameterFilter {$String1 -eq $unlimitedInt32.Value.ToString() -and $String2 -eq '2'} `
+                        -ParameterFilter { $String1 -eq $unlimitedInt32.Value.ToString() -and $String2 -eq '2' } `
                         -Verifiable `
                         -MockWith { return $true }
 
@@ -1790,12 +1792,12 @@ try
 
                     Mock `
                         -CommandName Convert-StringArrayToLowerCase `
-                        -ParameterFilter {$null -eq (Compare-Object -ReferenceObject $Array1Param -DifferenceObject $Array1 )} `
+                        -ParameterFilter { $null -eq (Compare-Object -ReferenceObject $Array1Param -DifferenceObject $Array1 ) } `
                         -Verifiable `
                         -MockWith { return $Array1Lower }
                     Mock `
                         -CommandName Convert-StringArrayToLowerCase `
-                        -ParameterFilter {$null -eq (Compare-Object -ReferenceObject $Array2Param -DifferenceObject $Array2 )} `
+                        -ParameterFilter { $null -eq (Compare-Object -ReferenceObject $Array2Param -DifferenceObject $Array2 ) } `
                         -Verifiable `
                         -MockWith { return $Array2Lower }
 
@@ -1843,12 +1845,12 @@ try
 
                     Mock `
                         -CommandName Convert-StringArrayToLowerCase `
-                        -ParameterFilter {$null -eq (Compare-Object -ReferenceObject $Array1Param -DifferenceObject $Array1 )} `
+                        -ParameterFilter { $null -eq (Compare-Object -ReferenceObject $Array1Param -DifferenceObject $Array1 ) } `
                         -Verifiable `
                         -MockWith { return $Array1Lower }
                     Mock `
                         -CommandName Convert-StringArrayToLowerCase `
-                        -ParameterFilter {$null -eq (Compare-Object -ReferenceObject $Array2Param -DifferenceObject $Array2 )} `
+                        -ParameterFilter { $null -eq (Compare-Object -ReferenceObject $Array2Param -DifferenceObject $Array2 ) } `
                         -Verifiable `
                         -MockWith { return $Array2Lower }
 
@@ -1976,12 +1978,12 @@ try
 
                     Mock `
                         -CommandName Convert-StringArrayToLowerCase `
-                        -ParameterFilter {$null -eq (Compare-Object -ReferenceObject $Array1Param -DifferenceObject $Array1 )} `
+                        -ParameterFilter { $null -eq (Compare-Object -ReferenceObject $Array1Param -DifferenceObject $Array1 ) } `
                         -Verifiable `
                         -MockWith { return $Array1Lower }
                     Mock `
                         -CommandName Convert-StringArrayToLowerCase `
-                        -ParameterFilter {$null -eq (Compare-Object -ReferenceObject $Array2Param -DifferenceObject $Array2 )} `
+                        -ParameterFilter { $null -eq (Compare-Object -ReferenceObject $Array2Param -DifferenceObject $Array2 ) } `
                         -Verifiable `
                         -MockWith { return $Array2Lower }
 
@@ -2023,12 +2025,12 @@ try
 
                     Mock `
                         -CommandName Convert-StringArrayToLowerCase `
-                        -ParameterFilter {$null -eq (Compare-Object -ReferenceObject $Array1Param -DifferenceObject $Array1 )} `
+                        -ParameterFilter { $null -eq (Compare-Object -ReferenceObject $Array1Param -DifferenceObject $Array1 ) } `
                         -Verifiable `
                         -MockWith { return $Array1Lower }
                     Mock `
                         -CommandName Convert-StringArrayToLowerCase `
-                        -ParameterFilter {$null -eq (Compare-Object -ReferenceObject $Array2Param -DifferenceObject $Array2 )} `
+                        -ParameterFilter { $null -eq (Compare-Object -ReferenceObject $Array2Param -DifferenceObject $Array2 ) } `
                         -Verifiable `
                         -MockWith { return $Array2Lower }
 
@@ -2112,11 +2114,11 @@ try
 
             Context 'When Add-ToPSBoundParametersFromHashtable is called, a parameter is added, and a parameter is changed' {
                 It 'Should add a new parameter and change the existing parameter' {
-                    $param1    = 'abc'
-                    $param2    = $null
+                    $param1 = 'abc'
+                    $param2 = $null
                     $param2new = 'notnull'
-                    $param3    = 'def'
-                    $param4    = 'ghi'
+                    $param3 = 'def'
+                    $param4 = 'ghi'
 
                     $psBoundParametersIn = @{
                         Param1 = $param1
@@ -2146,8 +2148,8 @@ try
 
             Context 'When Remove-FromPSBoundParametersUsingHashtable is called and both ParamsToKeep and ParamsToRemove are specified' {
                 It 'Should throw an exception' {
-                    { Remove-FromPSBoundParametersUsingHashtable -PSBoundParametersIn @{} -ParamsToKeep @('Param1') -ParamsToRemove @('Param2') } | `
-                        Should -Throw -ExpectedMessage 'Remove-FromPSBoundParametersUsingHashtable does not support using both ParamsToKeep and ParamsToRemove'
+                    { Remove-FromPSBoundParametersUsingHashtable -PSBoundParametersIn @{ } -ParamsToKeep @('Param1') -ParamsToRemove @('Param2') } | `
+                            Should -Throw -ExpectedMessage 'Remove-FromPSBoundParametersUsingHashtable does not support using both ParamsToKeep and ParamsToRemove'
                 }
             }
 
@@ -2275,11 +2277,11 @@ try
 
             Context 'When Write-InvalidSettingVerbose is called' {
                 It 'Should call Write-Verbose, and the message should contain the input values' {
-                    $setting  = 'TestSetting'
+                    $setting = 'TestSetting'
                     $expected = 'ExpectedTestValue'
-                    $actual   = 'ActualTestValue'
+                    $actual = 'ActualTestValue'
 
-                    Mock -CommandName Write-Verbose -ParameterFilter {$Message.Contains($setting) -and $Message.Contains($expected) -and $Message.Contains($actual)} -Verifiable
+                    Mock -CommandName Write-Verbose -ParameterFilter { $Message.Contains($setting) -and $Message.Contains($expected) -and $Message.Contains($actual) } -Verifiable
 
                     Write-InvalidSettingVerbose -SettingName $setting -ExpectedValue $expected -ActualValue $actual
                 }
@@ -2297,11 +2299,11 @@ try
                 It 'Should write the calling function name and no parameters' {
                     Mock -CommandName Get-PSCallStack -Verifiable -MockWith {
                         return @(
-                            @{FunctionName = 'Bottom-O-Stack'},
-                            @{FunctionName = $functionName}
+                            @{FunctionName = 'Bottom-O-Stack' },
+                            @{FunctionName = $functionName }
                         )
                     }
-                    Mock -CommandName Write-Verbose -ParameterFilter {$Message.Contains($functionName) -and !$Message.Contains('parameters')} -Verifiable
+                    Mock -CommandName Write-Verbose -ParameterFilter { $Message.Contains($functionName) -and !$Message.Contains('parameters') } -Verifiable
 
                     Write-FunctionEntry
                 }
@@ -2311,16 +2313,16 @@ try
                 It 'Should write the calling function name and parameters' {
                     Mock -CommandName Get-PSCallStack -Verifiable -MockWith {
                         return @(
-                            @{FunctionName = 'Bottom-O-Stack'},
-                            @{FunctionName = $functionName}
+                            @{FunctionName = 'Bottom-O-Stack' },
+                            @{FunctionName = $functionName }
                         )
                     }
                     Mock `
                         -CommandName Write-Verbose `
-                        -ParameterFilter {$Message.Contains($functionName) -and $Message.Contains('Param1') -and $Message.Contains('123') -and $Message.Contains('Param2') -and $Message.Contains('321')} `
+                        -ParameterFilter { $Message.Contains($functionName) -and $Message.Contains('Param1') -and $Message.Contains('123') -and $Message.Contains('Param2') -and $Message.Contains('321') } `
                         -Verifiable
 
-                    Write-FunctionEntry -Parameters @{Param1 = 123; Param2 = 321}
+                    Write-FunctionEntry -Parameters @{Param1 = 123; Param2 = 321 }
                 }
             }
         }
@@ -2365,10 +2367,18 @@ try
 
         Describe 'xExchangeHelper\Test-ExchangeSetting' -Tag 'Helper' {
             # Override functions that require types loaded by Exchange DLLs
-            function Compare-TimespanToString {}
-            function Compare-ByteQuantifiedSizeToString {}
-            function Compare-SmtpAddressToString {}
-            function Compare-PSCredential {}
+            function Compare-TimespanToString
+            {
+            }
+            function Compare-ByteQuantifiedSizeToString
+            {
+            }
+            function Compare-SmtpAddressToString
+            {
+            }
+            function Compare-PSCredential
+            {
+            }
 
             AfterEach {
                 Assert-VerifiableMock
@@ -2376,8 +2386,8 @@ try
 
             Context 'When Test-ExchangeSetting is called and the target type is not handled by the function' {
                 It 'Should throw an exception' {
-                    { Test-ExchangeSetting -Name 'Setting' -Type 'MissingType' -ExpectedValue 1 -ActualValue 2 -PSBoundParametersIn @{Setting = 1} } | `
-                        Should -Throw -ExpectedMessage 'Type not found: MissingType'
+                    { Test-ExchangeSetting -Name 'Setting' -Type 'MissingType' -ExpectedValue 1 -ActualValue 2 -PSBoundParametersIn @{Setting = 1 } } | `
+                            Should -Throw -ExpectedMessage 'Type not found: MissingType'
                 }
             }
 
@@ -2441,7 +2451,7 @@ try
 
                     Mock -CommandName $Function -Verifiable -MockWith { return $true }
 
-                    Test-ExchangeSetting -Name 'Setting' -Type $Type -ExpectedValue 1 -ActualValue 2 -PSBoundParametersIn @{Setting = 1} | Should -Be $true
+                    Test-ExchangeSetting -Name 'Setting' -Type $Type -ExpectedValue 1 -ActualValue 2 -PSBoundParametersIn @{Setting = 1 } | Should -Be $true
                 }
             }
 
@@ -2459,13 +2469,13 @@ try
                     Mock -CommandName $Function -Verifiable -MockWith { return $false }
                     Mock -CommandName Write-InvalidSettingVerbose -Verifiable
 
-                    Test-ExchangeSetting -Name 'Setting' -Type $Type -ExpectedValue 1 -ActualValue 2 -PSBoundParametersIn @{Setting = 1} | Should -Be $false
+                    Test-ExchangeSetting -Name 'Setting' -Type $Type -ExpectedValue 1 -ActualValue 2 -PSBoundParametersIn @{Setting = 1 } | Should -Be $false
                 }
             }
 
             Context 'When Test-ExchangeSetting is called, the Type is Int, and the types are equal' {
                 It 'Should return true' {
-                    Test-ExchangeSetting -Name 'Setting' -Type 'Int' -ExpectedValue 1 -ActualValue 1 -PSBoundParametersIn @{Setting = 1} | Should -Be $true
+                    Test-ExchangeSetting -Name 'Setting' -Type 'Int' -ExpectedValue 1 -ActualValue 1 -PSBoundParametersIn @{Setting = 1 } | Should -Be $true
                 }
             }
 
@@ -2473,7 +2483,7 @@ try
                 It 'Should return false' {
                     Mock -CommandName Write-InvalidSettingVerbose -Verifiable
 
-                    Test-ExchangeSetting -Name 'Setting' -Type 'Int' -ExpectedValue 1 -ActualValue 2 -PSBoundParametersIn @{Setting = 1} | Should -Be $false
+                    Test-ExchangeSetting -Name 'Setting' -Type 'Int' -ExpectedValue 1 -ActualValue 2 -PSBoundParametersIn @{Setting = 1 } | Should -Be $false
                 }
             }
 
@@ -2481,7 +2491,7 @@ try
                 It 'Should return true' {
                     Mock -CommandName Convert-StringArrayToLowerCase -Verifiable -MockWith { return @('none') }
 
-                    Test-ExchangeSetting -Name 'Setting' -Type 'ExtendedProtection' -ExpectedValue 1 -ActualValue '' -PSBoundParametersIn @{Setting = 1} | Should -Be $true
+                    Test-ExchangeSetting -Name 'Setting' -Type 'ExtendedProtection' -ExpectedValue 1 -ActualValue '' -PSBoundParametersIn @{Setting = 1 } | Should -Be $true
                 }
             }
 
@@ -2490,7 +2500,7 @@ try
                     Mock -CommandName Convert-StringArrayToLowerCase -Verifiable -MockWith { return @('none') }
                     Mock -CommandName Write-InvalidSettingVerbose -Verifiable
 
-                    Test-ExchangeSetting -Name 'Setting' -Type 'ExtendedProtection' -ExpectedValue 1 -ActualValue 'notempty' -PSBoundParametersIn @{Setting = 1} | Should -Be $false
+                    Test-ExchangeSetting -Name 'Setting' -Type 'ExtendedProtection' -ExpectedValue 1 -ActualValue 'notempty' -PSBoundParametersIn @{Setting = 1 } | Should -Be $false
                 }
             }
 
@@ -2498,7 +2508,7 @@ try
                 It 'Should return true' {
                     Mock -CommandName Compare-ArrayContent -Verifiable -MockWith { return $true }
 
-                    Test-ExchangeSetting -Name 'Setting' -Type 'ExtendedProtection' -ExpectedValue 1 -ActualValue '' -PSBoundParametersIn @{Setting = 1} | Should -Be $true
+                    Test-ExchangeSetting -Name 'Setting' -Type 'ExtendedProtection' -ExpectedValue 1 -ActualValue '' -PSBoundParametersIn @{Setting = 1 } | Should -Be $true
                 }
             }
 
@@ -2507,7 +2517,7 @@ try
                     Mock -CommandName Compare-ArrayContent -Verifiable -MockWith { return $false }
                     Mock -CommandName Write-InvalidSettingVerbose -Verifiable
 
-                    Test-ExchangeSetting -Name 'Setting' -Type 'ExtendedProtection' -ExpectedValue 1 -ActualValue '' -PSBoundParametersIn @{Setting = 1} | Should -Be $false
+                    Test-ExchangeSetting -Name 'Setting' -Type 'ExtendedProtection' -ExpectedValue 1 -ActualValue '' -PSBoundParametersIn @{Setting = 1 } | Should -Be $false
                 }
             }
         }
@@ -2711,8 +2721,12 @@ try
 
         Describe 'xExchangeHelper\Restart-ExistingAppPool' -Tag 'Helper' {
             # Allow override of IIS commands
-            function Get-WebAppPoolState {}
-            function Restart-WebAppPool {}
+            function Get-WebAppPoolState
+            {
+            }
+            function Restart-WebAppPool
+            {
+            }
 
             AfterEach {
                 Assert-VerifiableMock
@@ -2744,12 +2758,12 @@ try
                 Assert-VerifiableMock
             }
 
-            $password1      = ConvertTo-SecureString 'Password1' -AsPlainText -Force
+            $password1 = ConvertTo-SecureString 'Password1' -AsPlainText -Force
             $password1Upper = ConvertTo-SecureString 'PASSWORD1' -AsPlainText -Force
 
-            $user1      = 'user1'
+            $user1 = 'user1'
             $user1Upper = 'USER1'
-            $user2      = 'user2'
+            $user2 = 'user2'
 
             $trueCredentialComps = @(
                 @{
@@ -2818,9 +2832,15 @@ try
 
         Describe 'xExchangeHelper\Start-ExchangeScheduledTask' -Tag 'Helper' {
             # Override functions with non-Mockable parameter types
-            function Register-ScheduledTask {}
-            function Set-ScheduledTask {}
-            function Start-ScheduledTask {}
+            function Register-ScheduledTask
+            {
+            }
+            function Set-ScheduledTask
+            {
+            }
+            function Start-ScheduledTask
+            {
+            }
 
             AfterEach {
                 Assert-VerifiableMock

--- a/tests/Unit/xExchangeHelper.tests.ps1
+++ b/tests/Unit/xExchangeHelper.tests.ps1
@@ -1282,7 +1282,11 @@ try
                             State = 'Opened'
                         }
                     }
-                    Mock -CommandName New-RemoteExchangeSession
+                    Mock -CommandName New-RemoteExchangeSession -Verifiable -MockWith {
+                        return @{
+                            State = 'Opened'
+                        }
+                    }
                     Mock -CommandName Export-PSSession
                     Mock -CommandName Import-Module
 
@@ -1304,7 +1308,7 @@ try
                             State = 'Opened'
                         }
                     }
-                    Mock -CommandName Import-Module -ParameterFilter { $ArgumentList.State -eq 'Opened' } -Verifiable
+                    Mock -CommandName Import-Module -Verifiable
 
                     Get-RemoteExchangeSession
 
@@ -1314,7 +1318,7 @@ try
             }
 
             Context 'When Get-RemoteExchangeSession is called, setup is not running, exported module exists and there is a existing session' {
-                It 'Should create only import the module' {
+                It 'Should only import the module' {
                     Mock -CommandName Test-ExchangeSetupRunning -Verifiable -MockWith { return $false }
                     Mock -CommandName Get-ExistingRemoteExchangeSession -Verifiable -MockWith {
                         return @{
@@ -1322,7 +1326,7 @@ try
                         }
                     }
                     Mock -CommandName New-RemoteExchangeSession -Verifiable
-                    Mock -CommandName Import-Module -ParameterFilter { $ArgumentList.State -eq 'Opened' } -Verifiable
+                    Mock -CommandName Import-Module -ParameterFilter -Verifiable
 
                     Get-RemoteExchangeSession
 
@@ -1381,9 +1385,15 @@ try
             # Override functions which have non-Mockable parameter types
             function Export-PSSession
             {
+                param(
+                    $OutputModule
+                )
             }
             function Import-Module
             {
+                param(
+                    $Function
+                )
             }
 
             AfterEach {
@@ -1398,7 +1408,7 @@ try
                     Mock `
                         -CommandName Export-PSSession `
                         -Verifiable `
-                        -ParameterFilter { $OutputModule -eq "$env:TEMP\DSCExchangeModule" } -MockWith { return $true }
+                        -ParameterFilter { $OutputModule -eq "$env:TEMP\DSCExchangeModule" }
                     Mock `
                         -CommandName Import-Module `
                         -ParameterFilter { $Function.Count -eq 1 -and $Function[0] -like $commandToLoad } `
@@ -1413,7 +1423,7 @@ try
                     Mock `
                         -CommandName Export-PSSession `
                         -Verifiable `
-                        -ParameterFilter { $OutputModule -eq "$env:TEMP\DSCExchangeModule" } -MockWith { return $true }
+                        -ParameterFilter { $OutputModule -eq "$env:TEMP\DSCExchangeModule" }
                     Mock `
                         -CommandName Import-Module `
                         -ParameterFilter { $Function.Count -eq 1 -and $Function[0] -eq '*' } `

--- a/tests/Unit/xExchangeHelper.tests.ps1
+++ b/tests/Unit/xExchangeHelper.tests.ps1
@@ -1261,6 +1261,9 @@ try
         }
 
         Describe 'xExchangeHelper\Get-RemoteExchangeSession' -Tag 'Helper' {
+            function Export-PSSession {
+
+            }
             AfterEach {
                 Assert-VerifiableMock
             }
@@ -1325,12 +1328,11 @@ try
                             State = 'Opened'
                         }
                     }
-                    Mock -CommandName New-RemoteExchangeSession -Verifiable
-                    Mock -CommandName Import-Module -ParameterFilter -Verifiable
+                    Mock -CommandName Test-Path -ParameterFilter { $Path -eq "$env:TEMP\DSCExchangeModule" } -Verifiable -MockWith { $true }
+                    Mock -CommandName Import-Module -Verifiable
 
                     Get-RemoteExchangeSession
 
-                    Assert-MockCalled -CommandName New-RemoteExchangeSession -Times 0
                     Assert-MockCalled -CommandName Import-Module -Times 1
                 }
             }

--- a/tests/Unit/xExchangeHelper.tests.ps1
+++ b/tests/Unit/xExchangeHelper.tests.ps1
@@ -1261,12 +1261,15 @@ try
         }
 
         Describe 'xExchangeHelper\Get-RemoteExchangeSession' -Tag 'Helper' {
-            function Export-PSSession {
+            function Export-PSSession
+            {
 
             }
             AfterEach {
                 Assert-VerifiableMock
             }
+
+            $DSCExchangeModulePath = "$env:TEMP\DSCExchangeModule"
 
             Context 'When Get-RemoteExchangeSession is called and Exchange setup is running' {
                 It 'Should throw an exception' {
@@ -1305,7 +1308,7 @@ try
                 It 'Should create a session and import the module' {
                     Mock -CommandName Test-ExchangeSetupRunning -Verifiable -MockWith { return $false }
                     Mock -CommandName Get-ExistingRemoteExchangeSession -Verifiable -MockWith { return $null }
-                    Mock -CommandName Test-Path -ParameterFilter { $Path -eq "$env:TEMP\DSCExchangeModule" } -Verifiable -MockWith { $true }
+                    Mock -CommandName Test-Path -ParameterFilter { $Path -eq $DSCExchangeModulePath } -Verifiable -MockWith { $true }
                     Mock -CommandName New-RemoteExchangeSession -Verifiable -MockWith {
                         return @{
                             State = 'Opened'
@@ -1328,7 +1331,7 @@ try
                             State = 'Opened'
                         }
                     }
-                    Mock -CommandName Test-Path -ParameterFilter { $Path -eq "$env:TEMP\DSCExchangeModule" } -Verifiable -MockWith { $true }
+                    Mock -CommandName Test-Path -ParameterFilter { $Path -eq $DSCExchangeModulePath } -Verifiable -MockWith { $true }
                     Mock -CommandName Import-Module -Verifiable
 
                     Get-RemoteExchangeSession
@@ -1410,7 +1413,7 @@ try
                     Mock `
                         -CommandName Export-PSSession `
                         -Verifiable `
-                        -ParameterFilter { $OutputModule -eq "$env:TEMP\DSCExchangeModule" }
+                        -ParameterFilter { $OutputModule -eq $DSCExchangeModulePath }
                     Mock `
                         -CommandName Import-Module `
                         -ParameterFilter { $Function.Count -eq 1 -and $Function[0] -like $commandToLoad } `
@@ -1425,7 +1428,7 @@ try
                     Mock `
                         -CommandName Export-PSSession `
                         -Verifiable `
-                        -ParameterFilter { $OutputModule -eq "$env:TEMP\DSCExchangeModule" }
+                        -ParameterFilter { $OutputModule -eq $DSCExchangeModulePath }
                     Mock `
                         -CommandName Import-Module `
                         -ParameterFilter { $Function.Count -eq 1 -and $Function[0] -eq '*' } `

--- a/tests/Unit/xExchangeHelper.tests.ps1
+++ b/tests/Unit/xExchangeHelper.tests.ps1
@@ -1269,7 +1269,9 @@ try
                 Assert-VerifiableMock
             }
 
-            $DSCExchangeModulePath = "$env:TEMP\DSCExchangeModule"
+            $script:DSCExchangeModuleName = 'DSCExchangeModule'
+            $script:DSCExchangeModulePath = "$env:Temp\DSCExchangeModuleName"
+
 
             Context 'When Get-RemoteExchangeSession is called and Exchange setup is running' {
                 It 'Should throw an exception' {
@@ -1308,7 +1310,7 @@ try
                 It 'Should create a session and import the module' {
                     Mock -CommandName Test-ExchangeSetupRunning -Verifiable -MockWith { return $false }
                     Mock -CommandName Get-ExistingRemoteExchangeSession -Verifiable -MockWith { return $null }
-                    Mock -CommandName Test-Path -ParameterFilter { $Path -eq $DSCExchangeModulePath } -Verifiable -MockWith { $true }
+                    Mock -CommandName Test-Path -ParameterFilter { $Path -eq $script:DSCExchangeModulePath } -Verifiable -MockWith { $true }
                     Mock -CommandName New-RemoteExchangeSession -Verifiable -MockWith {
                         return @{
                             State = 'Opened'
@@ -1350,6 +1352,9 @@ try
             AfterEach {
                 Assert-VerifiableMock
             }
+
+            $script:DSCExchangeModuleName = 'DSCExchangeModule'
+            $script:DSCExchangeModulePath = "$env:Temp\DSCExchangeModuleName"
 
             Context 'When New-RemoteExchangeSession is called and Exchange is not installed' {
                 It 'Should throw an exception' {
@@ -1405,6 +1410,8 @@ try
                 Assert-VerifiableMock
             }
 
+            $script:DSCExchangeModuleName = 'DSCExchangeModule'
+            $script:DSCExchangeModulePath = "$env:Temp\DSCExchangeModuleName"
             $commandToLoad = 'Get-ExchangeServer'
             $commandsToLoad = @($commandToLoad)
 
@@ -1413,7 +1420,7 @@ try
                     Mock `
                         -CommandName Export-PSSession `
                         -Verifiable `
-                        -ParameterFilter { $OutputModule -eq $DSCExchangeModulePath }
+                        -ParameterFilter { $OutputModule -eq $script:DSCExchangeModulePath }
                     Mock `
                         -CommandName Import-Module `
                         -ParameterFilter { $Function.Count -eq 1 -and $Function[0] -like $commandToLoad } `
@@ -1428,7 +1435,7 @@ try
                     Mock `
                         -CommandName Export-PSSession `
                         -Verifiable `
-                        -ParameterFilter { $OutputModule -eq $DSCExchangeModulePath }
+                        -ParameterFilter { $OutputModule -eq $script:DSCExchangeModulePath }
                     Mock `
                         -CommandName Import-Module `
                         -ParameterFilter { $Function.Count -eq 1 -and $Function[0] -eq '*' } `


### PR DESCRIPTION
#### Pull Request (PR) description
Hallo,

as mentioned in #446  I noticed that for every DSC resource I have configured, there is a new explicit module created leading eventually to filling up the system drive. 
I have modified the helper function to save a module under $env:Temp.

#### This Pull Request (PR) fixes the following issues
    - Fixes #446 
#### Task list
- [x] Added an entry to the change log under the Unreleased section of the
      file CHANGELOG.md. Entry should say what was changed and how that
      affects users (if applicable), and reference the issue being resolved
      (if applicable).
- [ ] Resource documentation added/updated in README.md.
- [ ] Resource parameter descriptions added/updated in README.md, schema.mof
      and comment-based help.
- [ ] Comment-based help added/updated.
- [ ] Localization strings added/updated in all localization files as appropriate.
- [ ] Examples appropriately added/updated.
- [x] Unit tests added/updated. See [DSC Community Testing Guidelines](https://dsccommunity.org/guidelines/testing-guidelines).
- [ ] Integration tests added/updated (where possible). See [DSC Community Testing Guidelines](https://dsccommunity.org/guidelines/testing-guidelines).
- [x] New/changed code adheres to [DSC Community Style Guidelines](https://dsccommunity.org/styleguidelines).

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dsccommunity/xexchange/448)
<!-- Reviewable:end -->
