### PR TITLE
xExchangeHelper: Fix Exchange session removal

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@ For older change log history see the [historic changelog](HISTORIC_CHANGELOG.md)
   $env:Temp and reused every time DSC check runs, instead of creating a new
   module every time.
   - Added AD Permissions parameter for xExchReceiveConnector.
+  - Small bug fix in xExchangeHelper module.
 
 ## [1.31.0] - 2020-01-27
 

--- a/source/Modules/xExchangeHelper/xExchangeHelper.psm1
+++ b/source/Modules/xExchangeHelper/xExchangeHelper.psm1
@@ -23,7 +23,7 @@ function Get-ExistingRemoteExchangeSession
         }
         else # Session is in an unexpected state. Remove it so we can rebuild it
         {
-            Remove-RemoteExchangeSession
+            Remove-RemoteExchangeModule
             $session = $null
         }
     }


### PR DESCRIPTION
#### Pull Request (PR) description
In the Get-ExistingRemoteExchangeSession a call to a wrong function is invoked, when the remote exchange session needs to be removed. 

#### This Pull Request (PR) fixes the following issues
#### Task list
- [x] Added an entry to the change log under the Unreleased section of the
      file CHANGELOG.md. Entry should say what was changed and how that
      affects users (if applicable), and reference the issue being resolved
      (if applicable).
- [ ] Resource documentation added/updated in README.md.
- [ ] Resource parameter descriptions added/updated in README.md, schema.mof
      and comment-based help.
- [ ] Comment-based help added/updated.
- [ ] Localization strings added/updated in all localization files as appropriate.
- [ ] Examples appropriately added/updated.
- [ ] Unit tests added/updated. See [DSC Community Testing Guidelines](https://dsccommunity.org/guidelines/testing-guidelines).
- [ ] Integration tests added/updated (where possible). See [DSC Community Testing Guidelines](https://dsccommunity.org/guidelines/testing-guidelines).
- [x] New/changed code adheres to [DSC Community Style Guidelines](https://dsccommunity.org/styleguidelines).

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dsccommunity/xexchange/454)
<!-- Reviewable:end -->
