### PR TITLE
xExchAddressList: Remove creating of scriptblock for RecipientFilter

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,8 @@ For older change log history see the [historic changelog](HISTORIC_CHANGELOG.md)
   $env:Temp and reused every time DSC check runs, instead of creating a new
   module every time.
   - Added AD Permissions parameter for xExchReceiveConnector.
+  - xExchAddressList: Removing the scriptblock creation for RecipientFilter
+  property in Get-TargetResource.
 
 ## [1.31.0] - 2020-01-27
 

--- a/source/DSCResources/MSFT_xExchAddressList/MSFT_xExchAddressList.psm1
+++ b/source/DSCResources/MSFT_xExchAddressList/MSFT_xExchAddressList.psm1
@@ -114,14 +114,7 @@ function Get-TargetResource
         {
             if ($addressList.$property -and $addressListProperties -contains $property)
             {
-                if ($property -eq 'RecipientFilter')
-                {
-                    $returnValue[$property] = "{$($addressList.$property)}"
-                }
-                else
-                {
-                    $returnValue[$property] = $addressList.$property
-                }
+                $returnValue[$property] = $addressList.$property
             }
         }
     }

--- a/tests/Unit/MSFT_xExchAddressList.tests.ps1
+++ b/tests/Unit/MSFT_xExchAddressList.tests.ps1
@@ -90,7 +90,7 @@ try
                 Mock -CommandName Get-AddressList -Verifiable -MockWith { return [PSCustomObject] $getAddressCustomFilterOutput }
 
                 $returnValue = Get-TargetResource @getTargetResourceParams
-                $returnValue['RecipientFilter'] | Should -Be '{(RecipientType -eq "UserMailbox")}'
+                $returnValue['RecipientFilter'] | Should -Be '(RecipientType -eq "UserMailbox")'
             }
 
             Context 'When Addresslist is not present' {


### PR DESCRIPTION
#### Pull Request (PR) description
With this PR the creatiion of a scriptblock for the RecipientFilter property in Get-Targetresource is removed, as it's not required.

#### This Pull Request (PR) fixes the following issues

#### Task list
- [x] Added an entry to the change log under the Unreleased section of the
      file CHANGELOG.md. Entry should say what was changed and how that
      affects users (if applicable), and reference the issue being resolved
      (if applicable).
- [ ] Resource documentation added/updated in README.md.
- [ ] Resource parameter descriptions added/updated in README.md, schema.mof
      and comment-based help.
- [ ] Comment-based help added/updated.
- [ ] Localization strings added/updated in all localization files as appropriate.
- [ ] Examples appropriately added/updated.
- [x] Unit tests added/updated. See [DSC Community Testing Guidelines](https://dsccommunity.org/guidelines/testing-guidelines).
- [ ] Integration tests added/updated (where possible). See [DSC Community Testing Guidelines](https://dsccommunity.org/guidelines/testing-guidelines).
- [x] New/changed code adheres to [DSC Community Style Guidelines](https://dsccommunity.org/styleguidelines).

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dsccommunity/xexchange/455)
<!-- Reviewable:end -->
