### PR TITLE
xExchAcceptedDomain: Fixing the Get-TargetResource function

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,7 +19,9 @@ For older change log history see the [historic changelog](HISTORIC_CHANGELOG.md)
     Sampler 0.110.1 was released and is a breaking change,
     so we need to pin 0.109.1.
   - Add the function Remove-RemoteExchangeSession
-
+- xExchAcceptedDomain
+  - Fixing the Get-TargetResource function.
+  
 ## [1.32.0] - 2020-05-13
 
 ### Changed

--- a/source/DSCResources/MSFT_xExchAcceptedDomain/MSFT_xExchAcceptedDomain.psm1
+++ b/source/DSCResources/MSFT_xExchAcceptedDomain/MSFT_xExchAcceptedDomain.psm1
@@ -62,7 +62,12 @@ function Get-TargetResource
         {
             if ([String] $acceptedDomain.$property -and $acceptedDomainProperties -contains $property)
             {
-                $returnValue[$property] = $acceptedDomain.$property
+                if ($property -eq 'Default')
+                {
+                    $returnValue['MakeDefault'] = $acceptedDomain.$property
+                } else {
+                    $returnValue[$property] = $acceptedDomain.$property
+                }
             }
         }
     }

--- a/tests/Unit/MSFT_xExchAcceptedDomain.tests.ps1
+++ b/tests/Unit/MSFT_xExchAcceptedDomain.tests.ps1
@@ -56,7 +56,7 @@ try
                 AddressBookEnabled = [System.Boolean] $true
                 DomainName         = [System.String] 'fakedomain.com'
                 DomainType         = [System.String] 'Authoritative'
-                MakeDefault        = [System.Boolean] $false
+                Default        = [System.Boolean] $false
                 MatchSubDomains    = [System.Boolean] $false
                 Name               = [System.String] 'fakedomain.com'
             }


### PR DESCRIPTION
#### Pull Request (PR) description
I've noticed that, the name of the property for setting a default domain in the MOF file is 'MakeDefault', but the get-targetresource function actullay returns 'Default' in the return hashtable. 

#### Task list
- [x] Added an entry to the change log under the Unreleased section of the
      file CHANGELOG.md. Entry should say what was changed and how that
      affects users (if applicable), and reference the issue being resolved
      (if applicable).
- [ ] Resource documentation added/updated in README.md.
- [ ] Resource parameter descriptions added/updated in README.md, schema.mof
      and comment-based help.
- [ ] Comment-based help added/updated.
- [ ] Localization strings added/updated in all localization files as appropriate.
- [ ] Examples appropriately added/updated.
- [ ] Unit tests added/updated. See [DSC Community Testing Guidelines](https://dsccommunity.org/guidelines/testing-guidelines).
- [ ] Integration tests added/updated (where possible). See [DSC Community Testing Guidelines](https://dsccommunity.org/guidelines/testing-guidelines).
- [x] New/changed code adheres to [DSC Community Style Guidelines](https://dsccommunity.org/styleguidelines).

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dsccommunity/xexchange/458)
<!-- Reviewable:end -->
