### PR TITLE
xExchAddressList and xExchSendConnector: Fixes in the Get-TargetResource functions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,9 @@ For older change log history see the [historic changelog](HISTORIC_CHANGELOG.md)
   - Fixing the Get-TargetResource function in xExchAcceptedDomain.
   - Setting Pester version to 4.10.1, since changes in the Unit Tests are reuquired
   in order for Pester 5 to work properly.
+  - In xExchAddressList the property IncludedRecipients should be a single string
+  object and not an array.
+  
 ## [1.32.0] - 2020-05-13
 
 ### Changed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ For older change log history see the [historic changelog](HISTORIC_CHANGELOG.md)
 
 ## [Unreleased]
 
+### Changed
+
+- xExchange
+  - Fixing the Get-TargetResource function in xExchAcceptedDomain.
+  - Setting Pester version to 4.10.1, since changes in the Unit Tests are reuquired
+  in order for Pester 5 to work properly.
 ## [1.32.0] - 2020-05-13
 
 ### Changed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ For older change log history see the [historic changelog](HISTORIC_CHANGELOG.md)
   in order for Pester 5 to work properly.
   - In xExchAddressList the property IncludedRecipients should be a single string
   object and not an array.
+  - Fixing the Get-TargetResource function in xExchSendConnector.
   
 ## [1.32.0] - 2020-05-13
 

--- a/RequiredModules.psd1
+++ b/RequiredModules.psd1
@@ -11,7 +11,7 @@
     Sampler                     = 'latest'
     invokeBuild                 = 'latest'
     PSScriptAnalyzer            = 'latest'
-    pester                      = 'latest'
+    pester                      = '4.10.1'
     Plaster                     = 'latest'
     ModuleBuilder               = '1.0.0'
     MarkdownLinkCheck           = 'latest'

--- a/source/DSCResources/MSFT_xExchAcceptedDomain/MSFT_xExchAcceptedDomain.psm1
+++ b/source/DSCResources/MSFT_xExchAcceptedDomain/MSFT_xExchAcceptedDomain.psm1
@@ -62,7 +62,12 @@ function Get-TargetResource
         {
             if ([String] $acceptedDomain.$property -and $acceptedDomainProperties -contains $property)
             {
-                $returnValue[$property] = $acceptedDomain.$property
+                if ($property -eq 'Default')
+                {
+                    $returnValue['MakeDefault'] = $acceptedDomain.$property
+                } else {
+                    $returnValue[$property] = $acceptedDomain.$property
+                }
             }
         }
     }

--- a/source/DSCResources/MSFT_xExchAddressList/MSFT_xExchAddressList.psm1
+++ b/source/DSCResources/MSFT_xExchAddressList/MSFT_xExchAddressList.psm1
@@ -114,7 +114,14 @@ function Get-TargetResource
         {
             if ($addressList.$property -and $addressListProperties -contains $property)
             {
-                $returnValue[$property] = $addressList.$property
+                if ($property -match 'Conditional')
+                {
+                    $returnValue[$property] = [System.String[]] $addressList.$property
+                }
+                else
+                {
+                    $returnValue[$property] = $addressList.$property
+                }
             }
         }
     }

--- a/source/DSCResources/MSFT_xExchAddressList/MSFT_xExchAddressList.psm1
+++ b/source/DSCResources/MSFT_xExchAddressList/MSFT_xExchAddressList.psm1
@@ -282,7 +282,7 @@ function Set-TargetResource
 
         [Parameter()]
         [ValidateSet('MailboxUsers', 'MailContacts', 'MailGroups', 'MailUsers', 'Resources', 'AllRecipients')]
-        [System.String[]]
+        [System.String]
         $IncludedRecipients,
 
         [Parameter()]
@@ -512,7 +512,7 @@ function Test-TargetResource
 
         [Parameter()]
         [ValidateSet('MailboxUsers', 'MailContacts', 'MailGroups', 'MailUsers', 'Resources', 'AllRecipients')]
-        [System.String[]]
+        [System.String]
         $IncludedRecipients,
 
         [Parameter()]

--- a/source/DSCResources/MSFT_xExchAddressList/MSFT_xExchAddressList.schema.mof
+++ b/source/DSCResources/MSFT_xExchAddressList/MSFT_xExchAddressList.schema.mof
@@ -24,7 +24,7 @@ class MSFT_xExchAddressList : OMI_BaseResource
     [Write, Description("The ConditionalStateOrProvince parameter specifies a precanned filter that's based on the value of the recipient's StateOrProvince  property.")] String ConditionalStateOrProvince[];
     [Write, Description("The Container parameter specifies where to create the address list.")] String Container;
     [Write, Description("The DisplayName parameter specifies where to create the address list.")] String DisplayName;
-    [Write, Description("The IncludedRecipients parameter specifies where to create the address list."), ValueMap {"MailboxUsers", "MailContacts", "MailGroups", "MailUsers", "Resources", "AllRecipients"}, Values {"MailboxUsers", "MailContacts", "MailGroups", "MailUsers", "Resources", "AllRecipients"}] String IncludedRecipients[];
+    [Write, Description("The IncludedRecipients parameter specifies where to create the address list."), ValueMap {"MailboxUsers", "MailContacts", "MailGroups", "MailUsers", "Resources", "AllRecipients"}, Values {"MailboxUsers", "MailContacts", "MailGroups", "MailUsers", "Resources", "AllRecipients"}] String IncludedRecipients;
     [Write, Description("The RecipientContainer parameter specifies a filter that's based on the recipient's location in Active Directory.")] String RecipientContainer;
     [Write, Description("The RecipientFilter parameter specifies a custom OPath filter that's based on the value of any available recipient property.")] String RecipientFilter;
 };

--- a/source/DSCResources/MSFT_xExchSendConnector/MSFT_xExchSendConnector.psm1
+++ b/source/DSCResources/MSFT_xExchSendConnector/MSFT_xExchSendConnector.psm1
@@ -45,6 +45,7 @@ function Get-TargetResource
         $returnValue = @{
             Name                         = [System.String] $connector.Name
             AddressSpaces                = [System.String[]] $connector.AddressSpaces
+            AuthenticationCredential     = [System.Management.Automation.PSCredential] $connector.AuthenticationCredential
             Comment                      = [System.String] $connector.Comment
             ConnectionInactivityTimeout  = [System.String] $connector.ConnectionInactivityTimeout
             ConnectorType                = [System.String] $connector.ConnectorType
@@ -52,7 +53,6 @@ function Get-TargetResource
             DomainSecureEnabled          = [System.Boolean] $connector.DomainSecureEnabled
             Enabled                      = [System.Boolean] $connector.Enabled
             ErrorPolicies                = [System.String] $connector.ErrorPolicies
-            ExtendedProtectionPolicy     = [System.String] $connector.ExtendedProtectionPolicy
             ExtendedRightAllowEntries    = [Microsoft.Management.Infrastructure.CimInstance[]] $adPermissions['ExtendedRightAllowEntries']
             ExtendedRightDenyEntries     = [Microsoft.Management.Infrastructure.CimInstance[]] $adPermissions['ExtendedRightDenyEntries']
             ForceHELO                    = [System.Boolean] $connector.ForceHELO
@@ -72,7 +72,6 @@ function Get-TargetResource
             SourceIPAddress              = [System.String] $connector.SourceIPAddress
             SourceTransportServers       = [System.String[]] $connector.SourceTransportServers
             TlsDomain                    = [System.String] $connector.TlsDomain
-            TlsAuthLevel                 = [System.String] $connector.TlsAuthLevel
             UseExternalDNSServersEnabled = [System.Boolean] $connector.UseExternalDNSServersEnabled
             TlsCertificateName           = [System.String] $connector.TlsCertificateName
             Ensure                       = 'Present'
@@ -886,4 +885,5 @@ function Test-TargetResource
     }
 
     return $testResults
+}
 }

--- a/source/DSCResources/MSFT_xExchSendConnector/MSFT_xExchSendConnector.psm1
+++ b/source/DSCResources/MSFT_xExchSendConnector/MSFT_xExchSendConnector.psm1
@@ -886,4 +886,3 @@ function Test-TargetResource
 
     return $testResults
 }
-}

--- a/tests/Unit/MSFT_xExchAcceptedDomain.tests.ps1
+++ b/tests/Unit/MSFT_xExchAcceptedDomain.tests.ps1
@@ -56,7 +56,7 @@ try
                 AddressBookEnabled = [System.Boolean] $true
                 DomainName         = [System.String] 'fakedomain.com'
                 DomainType         = [System.String] 'Authoritative'
-                MakeDefault        = [System.Boolean] $false
+                Default        = [System.Boolean] $false
                 MatchSubDomains    = [System.Boolean] $false
                 Name               = [System.String] 'fakedomain.com'
             }

--- a/tests/Unit/MSFT_xExchAddressList.tests.ps1
+++ b/tests/Unit/MSFT_xExchAddressList.tests.ps1
@@ -50,7 +50,7 @@ try
 
             $getAddressPrecannedOutput = @{
                 Name                         = [System.String] 'MyCustomAddressList'
-                IncludedRecipients           = [System.String[]] 'MailboxUsers'
+                IncludedRecipients           = [System.String] 'MailboxUsers'
                 ConditionalCompany           = [System.String[]] ''
                 ConditionalCustomAttribute1  = [System.String[]] ''
                 ConditionalCustomAttribute10 = [System.String[]] ''
@@ -222,7 +222,7 @@ try
                 Mock -CommandName 'Get-TargetResource' -MockWith {
                     return @{
                         Name               = [System.String] 'MyCustomAddressList'
-                        IncludedRecipients = [System.String[]] 'MailboxUsers'
+                        IncludedRecipients = [System.String] 'MailboxUsers'
                         DisplayName        = [System.String] 'MyCustomAddressList'
                         Container          = '\'
                         Ensure             = 'Present'
@@ -232,7 +232,7 @@ try
                 Context 'When Displyname and Container are not specified' {
                     $testTargetInput = @{
                         Name               = [System.String] 'MyCustomAddressList'
-                        IncludedRecipients = [System.String[]] 'MailboxUsers'
+                        IncludedRecipients = [System.String] 'MailboxUsers'
                         Credential         = New-Object -TypeName System.Management.Automation.PSCredential -ArgumentList 'fakeuser', (New-Object -TypeName System.Security.SecureString)
                     }
                     It 'Should return True when all properties match' {
@@ -248,7 +248,7 @@ try
                 Context 'When Displyname and Container are specified' {
                     $testTargetInput = @{
                         Name               = [System.String] 'MyCustomAddressList'
-                        IncludedRecipients = [System.String[]] 'MailboxUsers'
+                        IncludedRecipients = [System.String] 'MailboxUsers'
                         DisplayName        = [System.String] 'MyCustomAddressList'
                         Container          = '\'
                         Credential         = New-Object -TypeName System.Management.Automation.PSCredential -ArgumentList 'fakeuser', (New-Object -TypeName System.Security.SecureString)
@@ -287,7 +287,7 @@ try
                 It 'Should return false' {
                     $testTargetInput = @{
                         Name               = [System.String] 'MyCustomAddressList'
-                        IncludedRecipients = [System.String[]] 'MailboxUsers'
+                        IncludedRecipients = [System.String] 'MailboxUsers'
                         Credential         = New-Object -TypeName System.Management.Automation.PSCredential -ArgumentList 'fakeuser', (New-Object -TypeName System.Security.SecureString)
                     }
 


### PR DESCRIPTION
#### Pull Request (PR) description
I have noticed, that for the xExchAddressList resource the IncludedRecipients property is set as an array, but it's actually a single string value.
In the Get-TargetResource function for xExchSendConnector one additional property (ExtendedProtectionPolicy) which is not part of a send connector object, is returned. 

#### Task list
- [x] Added an entry to the change log under the Unreleased section of the
      file CHANGELOG.md. Entry should say what was changed and how that
      affects users (if applicable), and reference the issue being resolved
      (if applicable).
- [ ] Resource documentation added/updated in README.md.
- [ ] Resource parameter descriptions added/updated in README.md, schema.mof
      and comment-based help.
- [ ] Comment-based help added/updated.
- [ ] Localization strings added/updated in all localization files as appropriate.
- [ ] Examples appropriately added/updated.
- [ ] Unit tests added/updated. See [DSC Community Testing Guidelines](https://dsccommunity.org/guidelines/testing-guidelines).
- [ ] Integration tests added/updated (where possible). See [DSC Community Testing Guidelines](https://dsccommunity.org/guidelines/testing-guidelines).
- [x] New/changed code adheres to [DSC Community Style Guidelines](https://dsccommunity.org/styleguidelines).

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dsccommunity/xexchange/459)
<!-- Reviewable:end -->
