### PR TITLE
Update xExchangeHelper to fix Bug with 2019 OS

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+- xExchange
+  - Export-PSSession not creating temporary directory Server 2019.([issue #481](https://github.com/dsccommunity/xExchange/issues/481)).
+
 ## [1.33.0] - 2021-10-31
 
 ### Changed

--- a/GitVersion.yml
+++ b/GitVersion.yml
@@ -1,5 +1,5 @@
 mode: ContinuousDelivery
-next-version: 1.31.0
+next-version: 4.12.0
 major-version-bump-message: '(breaking\schange|breaking|major)\b'
 minor-version-bump-message: '(adds?|features?|minor)\b'
 patch-version-bump-message: '\s?(fix|patch)'

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -25,7 +25,7 @@ stages:
       - job: Package_Module
         displayName: 'Package Module'
         pool:
-          vmImage: 'ubuntu 18.04'
+          vmImage: 'windows-2019'
         steps:
           - task: GitVersion@5
             name: gitVersion

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -31,7 +31,7 @@ stages:
             name: gitVersion
             displayName: 'Evaluate Next Version'
             inputs:
-              runtime: 'core'
+              runtime: 'full'
               configFilePath: 'GitVersion.yml'
           - task: PowerShell@2
             name: package

--- a/source/Modules/xExchangeHelper/xExchangeHelper.psm1
+++ b/source/Modules/xExchangeHelper/xExchangeHelper.psm1
@@ -94,7 +94,7 @@ function Get-RemoteExchangeSession
     $session = Get-ExistingRemoteExchangeSession -Verbose:$VerbosePreference
 
     # See if the Exchange Module is already exported to $env:Temp
-    $exportedModule = Test-Path -Path $script:DSCExchangeModulePath$script:DSCExchangeModuleName.psm1
+    $exportedModule = Test-Path -Path $script:DSCExchangeModulePath\$script:DSCExchangeModuleName.psm1
 
     # If the exported Exchange module does not exist, create a session and export it
     if ($exportedModule -eq $false)

--- a/source/Modules/xExchangeHelper/xExchangeHelper.psm1
+++ b/source/Modules/xExchangeHelper/xExchangeHelper.psm1
@@ -1,5 +1,6 @@
 $script:DSCExchangeModuleName = 'DSCExchangeModule'
 $script:DSCExchangeModulePath = "$env:Temp\DSCExchangeModule"
+New-Item -Path $script:DSCExchangeModulePath -Type Directory -Force
 
 <#
     .SYNOPSIS
@@ -93,7 +94,7 @@ function Get-RemoteExchangeSession
     $session = Get-ExistingRemoteExchangeSession -Verbose:$VerbosePreference
 
     # See if the Exchange Module is already exported to $env:Temp
-    $exportedModule = Test-Path -Path $script:DSCExchangeModulePath
+    $exportedModule = Test-Path -Path $script:DSCExchangeModulePath$script:DSCExchangeModuleName.psm1
 
     # If the exported Exchange module does not exist, create a session and export it
     if ($exportedModule -eq $false)
@@ -236,7 +237,7 @@ function Import-RemoteExchangeModule
         $CommandsToLoad = @('*')
     )
 
-    Export-PSSession -Session $Session -OutputModule $script:DSCExchangeModulePath
+    Export-PSSession -Session $Session -OutputModule $script:DSCExchangeModulePath -Force
     Import-Module -Name $script:DSCExchangeModulePath -Global -DisableNameChecking -Function $CommandsToLoad
 }
 

--- a/tests/Unit/xExchangeHelper.tests.ps1
+++ b/tests/Unit/xExchangeHelper.tests.ps1
@@ -1335,7 +1335,7 @@ try
                 It 'Should create a session and import the module' {
                     Mock -CommandName Test-ExchangeSetupRunning -Verifiable -MockWith { return $false }
                     Mock -CommandName Get-ExistingRemoteExchangeSession -Verifiable -MockWith { return $null }
-                    Mock -CommandName Test-Path -ParameterFilter { $Path -eq $script:DSCExchangeModulePath } -Verifiable -MockWith { $true }
+                    Mock -CommandName Test-Path -ParameterFilter { $Path -eq "$script:DSCExchangeModulePath\$script:DSCExchangeModuleName.psm1" } -Verifiable -MockWith { $true }
                     Mock -CommandName New-RemoteExchangeSession -Verifiable -MockWith {
                         return @{
                             State = 'Opened'
@@ -1358,7 +1358,7 @@ try
                             State = 'Opened'
                         }
                     }
-                    Mock -CommandName Test-Path -ParameterFilter { $Path -eq $DSCExchangeModulePath } -Verifiable -MockWith { $true }
+                    Mock -CommandName Test-Path -ParameterFilter { $Path -eq "$DSCExchangeModulePath\$DSCExchangeModuleName.psm1" } -Verifiable -MockWith { $true }
                     Mock -CommandName Import-Module -Verifiable
 
                     Get-RemoteExchangeSession


### PR DESCRIPTION
#### Pull Request (PR) description

xExchangeHelper.psm1 - Export-PSSession not creating temporary directory Server 2019. A bug was found as described in issue 481, the update has been tested and is working.

#### This Pull Request (PR) fixes the following issues
- Fixes #481 


#### Task list

<!--
    To aid community reviewers in reviewing and merging your PR, please take
    the time to run through the below checklist and make sure your PR has
    everything updated as required.

    Change to [x] for each task in the task list that applies to your PR.
    For those task that don't apply to you PR, leave those as is.
-->

- [x] Added an entry to the change log under the Unreleased section of the
      file CHANGELOG.md. Entry should say what was changed and how that
      affects users (if applicable), and reference the issue being resolved
      (if applicable).
- [ ] Resource documentation added/updated in README.md.
- [ ] Resource parameter descriptions added/updated in README.md, schema.mof
      and comment-based help.
- [ ] Comment-based help added/updated.
- [ ] Localization strings added/updated in all localization files as appropriate.
- [ ] Examples appropriately added/updated.
- [ ] Unit tests added/updated. See [DSC Community Testing Guidelines](https://dsccommunity.org/guidelines/testing-guidelines).
- [ ] Integration tests added/updated (where possible). See [DSC Community Testing Guidelines](https://dsccommunity.org/guidelines/testing-guidelines).
- [x] New/changed code adheres to [DSC Community Style Guidelines](https://dsccommunity.org/styleguidelines).

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dsccommunity/xexchange/482)
<!-- Reviewable:end -->
