### PR TITLE
`Test-ShouldUpgradeExchange` did not handle the version correctly (#410)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,8 +31,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   - Fixed typo.
 - xExchangeHelper
   - Fixed module import error ([issue #481](https://github.com/dsccommunity/xExchange/issues/481)).
-- xExchangeHelper
   - Fixed error on first Exchange Module import ([Issue #488](https://github.com/dsccommunity/xExchange/issues/488)).
+  - Changed return value of `Get-SetupExeVersion` to `System.Version` which fixes #410.
 
 ## [1.33.0] - 2021-10-31
 

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -18,6 +18,7 @@ variables:
   testArtifactName: testResults
   sourceFolderName: source
   defaultBranch: main
+  Agent.Source.Git.ShallowFetchDepth: 0
 
 stages:
   - stage: Build

--- a/source/Modules/xExchangeHelper/xExchangeHelper.psm1
+++ b/source/Modules/xExchangeHelper/xExchangeHelper.psm1
@@ -392,14 +392,10 @@ function Get-DetailedInstalledVersion
             $versionBuild = $Matches['VersionBuild']
         }
 
-        $versionDetails = @{
-            VersionMajor   = Get-ItemProperty -Path $uninstallKeyPath -Name 'VersionMajor' -ErrorAction SilentlyContinue | Select-Object -ExpandProperty VersionMajor
-            VersionMinor   = Get-ItemProperty -Path $uninstallKeyPath -Name 'VersionMinor' -ErrorAction SilentlyContinue | Select-Object -ExpandProperty VersionMinor
-            VersionBuild   = $versionBuild
-            DisplayVersion = $displayVersion
-        }
+        $versionMajor = Get-ItemProperty -Path $uninstallKeyPath -Name 'VersionMajor' -ErrorAction SilentlyContinue | Select-Object -ExpandProperty VersionMajor
+        $versionMinor = Get-ItemProperty -Path $uninstallKeyPath -Name 'VersionMinor' -ErrorAction SilentlyContinue | Select-Object -ExpandProperty VersionMinor
 
-        $installedVersionDetails = New-Object -TypeName PSCustomObject -Property $versionDetails
+        $installedVersionDetails = [System.Version]::new($versionMajor, $versionMinor, $versionBuild)
     }
 
     return $installedVersionDetails
@@ -518,17 +514,12 @@ function Get-SetupExeVersion
     {
         $setupexeVersionInfo = (Get-ChildItem -Path $Path).VersionInfo
 
-        $setupexeVersionInfo = @{
-            VersionMajor = [System.Int32] $setupexeVersionInfo.ProductMajorPart
-            VersionMinor = [System.Int32] $setupexeVersionInfo.ProductMinorPart
-            VersionBuild = [System.Int32] $setupexeVersionInfo.ProductBuildPart
-        }
-
-        $version = New-Object -TypeName PSCustomObject -Property $setupexeVersionInfo
+        $version = [System.Version]::new($setupexeVersionInfo.ProductMajorPart, $setupexeVersionInfo.ProductMinorPart, $setupexeVersionInfo.ProductBuildPart)
     }
 
     return $version
 }
+
 
 <#
     .SYNOPSIS
@@ -569,25 +560,25 @@ function Test-ShouldUpgradeExchange
     $setupExeVersion = Get-SetupExeVersion -Path $Path
 
     if ($null -ne $setupExeVersion`
-            -and $null -ne $setupExeVersion.VersionMajor`
-            -and $null -ne $setupExeVersion.VersionMinor`
-            -and $null -ne $setupExeVersion.VersionBuild)
+            -and $null -ne $setupExeVersion.Major`
+            -and $null -ne $setupExeVersion.Minor`
+            -and $null -ne $setupExeVersion.Build)
     {
         Write-Verbose -Message "Setup.exe version is: '$('Major: {0}, Minor: {1}, Build: {2}' -f $setupExeVersion.VersionMajor,$setupexeVersion.VersionMinor, $setupexeVersion.VersionBuild)'"
 
         $exchangeDisplayVersion = Get-DetailedInstalledVersion
 
         if ($null -ne $exchangeDisplayVersion`
-                -and $null -ne $exchangeDisplayVersion.VersionMajor`
-                -and $null -ne $exchangeDisplayVersion.VersionMinor`
-                -and $null -ne $exchangeDisplayVersion.VersionBuild)
+                -and $null -ne $exchangeDisplayVersion.Major`
+                -and $null -ne $exchangeDisplayVersion.Minor`
+                -and $null -ne $exchangeDisplayVersion.Build)
         {
             # If we have an exchange installed
             Write-Verbose -Message "Exchange version is: '$('Major: {0}, Minor: {1}, Build: {2}' -f $exchangeDisplayVersion.VersionMajor,$exchangeDisplayVersion.VersionMinor, $exchangeDisplayVersion.VersionBuild)'"
 
-            if (($exchangeDisplayVersion.VersionMajor -eq $setupExeVersion.VersionMajor)`
-                    -and ($exchangeDisplayVersion.VersionMinor -eq $setupExeVersion.VersionMinor)`
-                    -and ($exchangeDisplayVersion.VersionBuild -lt $setupExeVersion.VersionBuild) )
+            if (($exchangeDisplayVersion.Major -eq $setupExeVersion.Major)`
+                    -and ($exchangeDisplayVersion.Minor -eq $setupExeVersion.Minor)`
+                    -and ($exchangeDisplayVersion.Build -lt $setupExeVersion.Build) )
             {
                 # If server has lower version of CU installed
                 Write-Verbose -Message 'Version upgrade is requested.'

--- a/source/Modules/xExchangeHelper/xExchangeHelper.psm1
+++ b/source/Modules/xExchangeHelper/xExchangeHelper.psm1
@@ -305,11 +305,11 @@ function Get-ExchangeVersionYear
 
     if ($null -ne $installedVersionDetails)
     {
-        switch ($installedVersionDetails.VersionMajor)
+        switch ($installedVersionDetails.Major)
         {
             15
             {
-                switch ($installedVersionDetails.VersionMinor)
+                switch ($installedVersionDetails.Minor)
                 {
                     0
                     {
@@ -490,7 +490,7 @@ function Test-ExchangeSetupPartiallyCompleted
 <#
     .SYNOPSIS
        Gets Exchange's setup.exe file's version info.
-       It will return VersionMajor, VersionMinor, VersionBuild values as PSCustomObject
+       It will return a System.Version object
        or NULL if not readable.
 
     .PARAMETER Path
@@ -564,7 +564,7 @@ function Test-ShouldUpgradeExchange
             -and $null -ne $setupExeVersion.Minor`
             -and $null -ne $setupExeVersion.Build)
     {
-        Write-Verbose -Message "Setup.exe version is: '$('Major: {0}, Minor: {1}, Build: {2}' -f $setupExeVersion.VersionMajor,$setupexeVersion.VersionMinor, $setupexeVersion.VersionBuild)'"
+        Write-Verbose -Message "Setup.exe version is: '$('Major: {0}, Minor: {1}, Build: {2}' -f $setupExeVersion.Major, $setupexeVersion.Minor, $setupexeVersion.Build)'"
 
         $exchangeDisplayVersion = Get-DetailedInstalledVersion
 
@@ -574,7 +574,7 @@ function Test-ShouldUpgradeExchange
                 -and $null -ne $exchangeDisplayVersion.Build)
         {
             # If we have an exchange installed
-            Write-Verbose -Message "Exchange version is: '$('Major: {0}, Minor: {1}, Build: {2}' -f $exchangeDisplayVersion.VersionMajor,$exchangeDisplayVersion.VersionMinor, $exchangeDisplayVersion.VersionBuild)'"
+            Write-Verbose -Message "Exchange version is: '$('Major: {0}, Minor: {1}, Build: {2}' -f $exchangeDisplayVersion.Major, $exchangeDisplayVersion.Minor, $exchangeDisplayVersion.Build)'"
 
             if (($exchangeDisplayVersion.Major -eq $setupExeVersion.Major)`
                     -and ($exchangeDisplayVersion.Minor -eq $setupExeVersion.Minor)`

--- a/source/Modules/xExchangeHelper/xExchangeHelper.psm1
+++ b/source/Modules/xExchangeHelper/xExchangeHelper.psm1
@@ -385,17 +385,17 @@ function Get-DetailedInstalledVersion
         $displayVersion = Get-ItemProperty -Path $uninstallKeyPath -Name 'DisplayVersion' -ErrorAction SilentlyContinue | Select-Object -ExpandProperty DisplayVersion
 
         $versionBuild = $null
-        $displayVersion -match '(?<VersionMajor>\d+).(?<VersionMinor>\d+).(?<VersionBuild>\d+)'
 
-        if ($Matches)
+        if ($displayVersion -match '(?<VersionMajor>\d+).(?<VersionMinor>\d+).(?<VersionBuild>\d+).(?<VersionRevision>\d+)')
         {
             $versionBuild = $Matches['VersionBuild']
+            $versionRevision = $Matches['VersionRevision']
         }
 
         $versionMajor = Get-ItemProperty -Path $uninstallKeyPath -Name 'VersionMajor' -ErrorAction SilentlyContinue | Select-Object -ExpandProperty VersionMajor
         $versionMinor = Get-ItemProperty -Path $uninstallKeyPath -Name 'VersionMinor' -ErrorAction SilentlyContinue | Select-Object -ExpandProperty VersionMinor
 
-        $installedVersionDetails = [System.Version]::new($versionMajor, $versionMinor, $versionBuild)
+        $installedVersionDetails = [System.Version]::new($versionMajor, $versionMinor, $versionBuild, $versionRevision)
     }
 
     return $installedVersionDetails

--- a/tests/Unit/xExchangeHelper.tests.ps1
+++ b/tests/Unit/xExchangeHelper.tests.ps1
@@ -1049,13 +1049,13 @@ try
 
             Context 'When DetailedInstalledVersion is called and a valid key is returned by Get-ExchangeUninstallKey' {
                 It 'Should return custom object with Major and Minor properties' {
-                    Mock -CommandName Get-ExchangeUninstallKey -Verifiable -MockWith { return @{Name = 'SomeKeyName' } }
+                    Mock -CommandName Get-ExchangeUninstallKey -Verifiable -MockWith { return @{ Name = 'SomeKeyName' } }
                     Mock -CommandName Get-ItemProperty -Verifiable -ParameterFilter { $Name -eq 'DisplayVersion' } -MockWith {
                         return [PSCustomObject] @{ DisplayVersion = '15.1.1531.13' } }
-                    Mock -CommandName Get-ItemProperty -Verifiable -ParameterFilter { $Name -eq 'Major' } -MockWith {
-                        return [PSCustomObject] @{ Major = 15 } }
-                    Mock -CommandName Get-ItemProperty -Verifiable -ParameterFilter { $Name -eq 'Minor' } -MockWith {
-                        return [PSCustomObject] @{ Minor = 1 }
+                    Mock -CommandName Get-ItemProperty -Verifiable -ParameterFilter { $Name -eq 'VersionMajor' } -MockWith {
+                        return [PSCustomObject] @{ VersionMajor = 15 } }
+                    Mock -CommandName Get-ItemProperty -Verifiable -ParameterFilter { $Name -eq 'VersionMinor' } -MockWith {
+                        return [PSCustomObject] @{ VersionMinor = 1 }
                     }
 
                     $installedVersionDetails = Get-DetailedInstalledVersion

--- a/tests/Unit/xExchangeHelper.tests.ps1
+++ b/tests/Unit/xExchangeHelper.tests.ps1
@@ -1051,19 +1051,20 @@ try
                 It 'Should return custom object with VersionMajor and VersionMinor properties' {
                     Mock -CommandName Get-ExchangeUninstallKey -Verifiable -MockWith { return @{Name = 'SomeKeyName' } }
                     Mock -CommandName Get-ItemProperty -Verifiable -ParameterFilter { $Name -eq 'DisplayVersion' } -MockWith {
-                        return [PSCustomObject] @{DisplayVersion = '15.1.1531.13' } }
+                        return [PSCustomObject] @{ DisplayVersion = '15.1.1531.13' } }
                     Mock -CommandName Get-ItemProperty -Verifiable -ParameterFilter { $Name -eq 'VersionMajor' } -MockWith {
-                        return [PSCustomObject] @{VersionMajor = 15 } }
+                        return [PSCustomObject] @{ VersionMajor = 15 } }
                     Mock -CommandName Get-ItemProperty -Verifiable -ParameterFilter { $Name -eq 'VersionMinor' } -MockWith {
                         return [PSCustomObject] @{ VersionMinor = 1 }
                     }
 
                     $installedVersionDetails = Get-DetailedInstalledVersion
 
-                    $installedVersionDetails.VersionMajor | Should -Be 15
-                    $installedVersionDetails.VersionMinor | Should -Be 1
-                    $installedVersionDetails.VersionBuild | Should -Be 1531
-                    $installedVersionDetails.DisplayVersion | Should -Be '15.1.1531.13'
+                    $installedVersionDetails.Major      | Should -Be 15
+                    $installedVersionDetails.Minor      | Should -Be 1
+                    $installedVersionDetails.Build      | Should -Be 1531
+                    $installedVersionDetails.Revision   | Should -Be 13
+                    $installedVersionDetails.ToString() | Should -Be '15.1.1531.13'
                 }
             }
 

--- a/tests/Unit/xExchangeHelper.tests.ps1
+++ b/tests/Unit/xExchangeHelper.tests.ps1
@@ -905,44 +905,44 @@ try
 
             $validProductVersions = @(
                 @{
-                    VersionMajor = 15
-                    VersionMinor = 0
+                    Major = 15
+                    Minor = 0
                     Year         = '2013'
                 }
                 @{
-                    VersionMajor = 15
-                    VersionMinor = 1
+                    Major = 15
+                    Minor = 1
                     Year         = '2016'
                 }
                 @{
-                    VersionMajor = 15
-                    VersionMinor = 2
+                    Major = 15
+                    Minor = 2
                     Year         = '2019'
                 }
             )
 
             $invalidProductVersions = @(
                 @{
-                    VersionMajor = 15
-                    VersionMinor = 7
+                    Major = 15
+                    Minor = 7
                     Year         = $null
                 }
                 @{
-                    VersionMajor = 14
-                    VersionMinor = 0
+                    Major = 14
+                    Minor = 0
                     Year         = $null
                 }
             )
 
-            Context 'When Get-ExchangeVersionYear is called and finds a valid VersionMajor and VersionMinor' {
+            Context 'When Get-ExchangeVersionYear is called and finds a valid Major and Minor' {
                 It 'Should return the correct Exchange year' -TestCases $validProductVersions {
                     param
                     (
                         [System.Int32]
-                        $VersionMajor,
+                        $Major,
 
                         [System.Int32]
-                        $VersionMinor,
+                        $Minor,
 
                         [System.String]
                         $Year
@@ -950,8 +950,8 @@ try
 
                     Mock -CommandName Get-DetailedInstalledVersion -Verifiable -MockWith {
                         return @{
-                            VersionMajor = $VersionMajor
-                            VersionMinor = $VersionMinor
+                            Major = $Major
+                            Minor = $Minor
                         }
                     }
 
@@ -959,15 +959,15 @@ try
                 }
             }
 
-            Context 'When Get-ExchangeVersionYear is called and finds an invalid VersionMajor or VersionMinor without ThrowIfUnknownVersion' {
+            Context 'When Get-ExchangeVersionYear is called and finds an invalid Major or Minor without ThrowIfUnknownVersion' {
                 It 'Should return <Year>' -TestCases $invalidProductVersions {
                     param
                     (
                         [System.Int32]
-                        $VersionMajor,
+                        $Major,
 
                         [System.Int32]
-                        $VersionMinor,
+                        $Minor,
 
                         [System.String]
                         $Year
@@ -975,8 +975,8 @@ try
 
                     Mock -CommandName Get-DetailedInstalledVersion -Verifiable -MockWith {
                         return @{
-                            VersionMajor = $VersionMajor
-                            VersionMinor = $VersionMinor
+                            Major = $Major
+                            Minor = $Minor
                         }
                     }
 
@@ -984,15 +984,15 @@ try
                 }
             }
 
-            Context 'When Get-ExchangeVersionYear is called and finds an invalid VersionMajor or VersionMinor and ThrowIfUnknownVersion is specified' {
+            Context 'When Get-ExchangeVersionYear is called and finds an invalid Major or Minor and ThrowIfUnknownVersion is specified' {
                 It 'Should throw an exception' -TestCases $invalidProductVersions {
                     param
                     (
                         [System.Int32]
-                        $VersionMajor,
+                        $Major,
 
                         [System.Int32]
-                        $VersionMinor,
+                        $Minor,
 
                         [System.String]
                         $Year
@@ -1000,8 +1000,8 @@ try
 
                     Mock -CommandName Get-DetailedInstalledVersion -Verifiable -MockWith {
                         return @{
-                            VersionMajor = $VersionMajor
-                            VersionMinor = $VersionMinor
+                            Major = $Major
+                            Minor = $nMinor
                         }
                     }
 
@@ -1048,14 +1048,14 @@ try
             }
 
             Context 'When DetailedInstalledVersion is called and a valid key is returned by Get-ExchangeUninstallKey' {
-                It 'Should return custom object with VersionMajor and VersionMinor properties' {
+                It 'Should return custom object with Major and Minor properties' {
                     Mock -CommandName Get-ExchangeUninstallKey -Verifiable -MockWith { return @{Name = 'SomeKeyName' } }
                     Mock -CommandName Get-ItemProperty -Verifiable -ParameterFilter { $Name -eq 'DisplayVersion' } -MockWith {
                         return [PSCustomObject] @{ DisplayVersion = '15.1.1531.13' } }
-                    Mock -CommandName Get-ItemProperty -Verifiable -ParameterFilter { $Name -eq 'VersionMajor' } -MockWith {
-                        return [PSCustomObject] @{ VersionMajor = 15 } }
-                    Mock -CommandName Get-ItemProperty -Verifiable -ParameterFilter { $Name -eq 'VersionMinor' } -MockWith {
-                        return [PSCustomObject] @{ VersionMinor = 1 }
+                    Mock -CommandName Get-ItemProperty -Verifiable -ParameterFilter { $Name -eq 'Major' } -MockWith {
+                        return [PSCustomObject] @{ Major = 15 } }
+                    Mock -CommandName Get-ItemProperty -Verifiable -ParameterFilter { $Name -eq 'Minor' } -MockWith {
+                        return [PSCustomObject] @{ Minor = 1 }
                     }
 
                     $installedVersionDetails = Get-DetailedInstalledVersion
@@ -1174,17 +1174,17 @@ try
 
                     Mock -CommandName Get-SetupExeVersion -Verifiable -MockWith {
                         return [PSCustomObject] @{
-                            VersionMajor = $SetupVersionMajor
-                            VersionMinor = $SetupVersionMinor
-                            VersionBuild = $SetupVersionBuild
+                            Major = $SetupVersionMajor
+                            Minor = $SetupVersionMinor
+                            Build = $SetupVersionBuild
                         }
                     }
 
                     Mock -CommandName Get-DetailedInstalledVersion -Verifiable -MockWith {
                         return [PSCustomObject] @{
-                            VersionMajor = $ExchangeVersionMajor
-                            VersionMinor = $ExchangeVersionMinor
-                            VersionBuild = $ExchangeVersionBuild
+                            Major = $ExchangeVersionMajor
+                            Minor = $ExchangeVersionMinor
+                            Build = $ExchangeVersionBuild
                         }
                     }
 
@@ -1214,9 +1214,9 @@ try
 
                     Mock -CommandName Get-SetupExeVersion -Verifiable -MockWith {
                         return [PSCustomObject] @{
-                            VersionMajor = 15
-                            VersionMinor = 1
-                            VersionBuild = 1234
+                            Major = 15
+                            Minor = 1
+                            Build = 1234
                         }
                     }
 

--- a/tests/Unit/xExchangeHelper.tests.ps1
+++ b/tests/Unit/xExchangeHelper.tests.ps1
@@ -1270,9 +1270,9 @@ try
 
                     $version = Get-SetupExeVersion -Path 'SomePath'
 
-                    $version.VersionMajor | Should -Be 1
-                    $version.VersionMinor | Should -Be 2
-                    $version.VersionBuild | Should -Be 3
+                    $version.Major | Should -Be 1
+                    $version.Minor | Should -Be 2
+                    $version.Build | Should -Be 3
                 }
             }
 


### PR DESCRIPTION
#### Pull Request (PR) description

This fixes #410 by changing how the version is compared. `Get-DetailedInstalledVersion` does no longer return a `PSCustomObject` reflecting the version but an object of type `System.Version`. The tests and `Test-ShouldUpgradeExchange` have been changed accordingly.

#### This Pull Request (PR) fixes the following issues

- Fixes #410

#### Task list

- [x] Added an entry to the change log under the Unreleased section of the file CHANGELOG.md.
      Entry should say what was changed and how that affects users (if applicable), and
      reference the issue being resolved (if applicable).
- [ ] Resource documentation added/updated in README.md.
- [ ] Resource parameter descriptions added/updated in README.md, schema.mof and comment-based
      help.
- [ ] Comment-based help added/updated.
- [ ] Localization strings added/updated in all localization files as appropriate.
- [ ] Examples appropriately added/updated.
- [x] Unit tests added/updated. See [DSC Community Testing Guidelines](https://dsccommunity.org/guidelines/testing-guidelines).
- [ ] Integration tests added/updated (where possible). See [DSC Community Testing Guidelines](https://dsccommunity.org/guidelines/testing-guidelines).
- [x] New/changed code adheres to [DSC Community Style Guidelines](https://dsccommunity.org/styleguidelines).

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dsccommunity/xExchange/494)
<!-- Reviewable:end -->
